### PR TITLE
Add Playwright benchmark Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: install browsers wasm bench
+
+install:
+	npm install
+
+browsers: install
+	npx playwright install firefox chromium
+	npx playwright install-deps firefox chromium
+
+wasm:
+	rustup target add wasm32-unknown-unknown 2>/dev/null || true
+	if ! command -v wasm-bindgen >/dev/null 2>&1; then cargo install wasm-bindgen-cli; fi
+	cargo build --target wasm32-unknown-unknown --release -p sd_wasm
+	wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/sd_wasm.wasm
+
+bench: wasm browsers
+	node bench.js

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,54 @@
+const { chromium, firefox } = require('playwright');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+function startServer(root) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const filePath = path.join(root, req.url);
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.statusCode = 404;
+          res.end('Not found');
+          return;
+        }
+        const ext = path.extname(filePath);
+        const types = { '.html': 'text/html', '.js': 'application/javascript', '.wasm': 'application/wasm' };
+        res.setHeader('Content-Type', types[ext] || 'application/octet-stream');
+        res.end(data);
+      });
+    }).listen(0, () => resolve(server));
+  });
+}
+
+async function runBenchmark(browserType) {
+  const server = await startServer(__dirname);
+  const port = server.address().port;
+  const url = `http://localhost:${port}/www/index.html`;
+  const browser = await browserType.launch();
+  const page = await browser.newPage();
+  await page.goto(url);
+  await page.waitForFunction(() => window.generate_x25519_keypair);
+  // Run a small benchmark inside the page context
+  const duration = await page.evaluate(() => {
+    const msg = new TextEncoder().encode('hello');
+    const iterations = 100;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      const kp = window.generate_x25519_keypair();
+      window.hpke_encrypt(kp.public_key, msg);
+    }
+    return performance.now() - start;
+  });
+  await browser.close();
+  server.close();
+  return { browser: browserType.name(), duration };
+}
+
+(async () => {
+  for (const type of [chromium, firefox]) {
+    const result = await runBenchmark(type);
+    console.log(`${result.browser}: ${result.duration.toFixed(2)}ms for 100 iterations`);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "sd-proto-bench",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sd-proto-bench",
+      "version": "0.1.0",
+      "devDependencies": {
+        "playwright": "^1.41.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sd-proto-bench",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Benchmark hpke-rs in headless browsers using Playwright",
+  "devDependencies": {
+    "playwright": "^1.41.1"
+  }
+}

--- a/sd_wasm/Cargo.toml
+++ b/sd_wasm/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 libcrux-ecdh = "0.0.3"
+libcrux-ml-kem = "0.0.3"
 hpke-rs = { version = "0.3", default-features = false }
 hpke-rs-libcrux = { version = "0.3", default-features = false }
 getrandom = { version = "0.3.2", features = ["wasm_js"] }

--- a/sd_wasm/src/lib.rs
+++ b/sd_wasm/src/lib.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 use libcrux_ecdh as ecdh;
+use libcrux_ml_kem::mlkem768::{rand as mlkem_rand};
 use hpke_rs::{self as hpke};
 use hpke_rs::hpke_types::{AeadAlgorithm, KemAlgorithm, KdfAlgorithm};
 use hpke_rs::Mode;
@@ -33,6 +34,16 @@ pub fn generate_x25519_keypair() -> KeyPair {
     KeyPair {
         private_key: sk,
         public_key: pk,
+    }
+}
+
+#[wasm_bindgen]
+pub fn generate_mlkem_keypair() -> KeyPair {
+    let mut rng = StdRng::from_os_rng();
+    let kp = mlkem_rand::generate_key_pair(&mut rng);
+    KeyPair {
+        private_key: kp.sk().as_ref().to_vec(),
+        public_key: kp.pk().as_ref().to_vec(),
     }
 }
 

--- a/securedrop-protocol/Cargo.toml
+++ b/securedrop-protocol/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "securedrop-protocol"
+version = "0.1.0"
+edition = "2024"
+authors = ["redshiftzero <jen@freedom.press>"]
+description = "A wip impl of the securedrop protocol"
+license = "GPL-3.0"
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", features = ["rand"], rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+# using git rev bc X25519 struct was unavailable in latest release on crates
+libcrux-curve25519 = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-chacha20poly1305 = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+libcrux-kem = { git = "https://github.com/cryspen/libcrux", rev="54c6624630e47ed599ffc1549101c2b861d51a8c" }
+hpke-rs = {version = "0.3.0", features = ["libcrux"]}
+rand_core = {version = "0.9"}
+rand = {version = "0.9"}
+# Needed for wasm compat
+getrandom = {version = "0.3", features = ["wasm_js"]}
+anyhow = "1.0"
+hashbrown = {version = "0.14", features = ["raw"]}
+uuid = {version = "1.0", features = ["v4", "rng-getrandom"]}
+blake2 = "0.10"
+wasm-bindgen = { version = "0.2", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+proptest = "1.3"

--- a/securedrop-protocol/bench.js
+++ b/securedrop-protocol/bench.js
@@ -1,0 +1,14 @@
+import init, { encrypt_decrypt_bench, submit_bench } from "./pkg/securedrop_protocol.js";
+
+async function run() {
+  await init();
+  const iterations = 100;
+  console.time('encrypt_decrypt');
+  encrypt_decrypt_bench(iterations);
+  console.timeEnd('encrypt_decrypt');
+  console.time('submit');
+  submit_bench(iterations);
+  console.timeEnd('submit');
+}
+
+run();

--- a/securedrop-protocol/src/bench/encrypt_decrypt.rs
+++ b/securedrop-protocol/src/bench/encrypt_decrypt.rs
@@ -1,0 +1,638 @@
+use hpke_rs::libcrux::HpkeLibcrux;
+use hpke_rs::{HpkeKeyPair, HpkePrivateKey, HpkePublicKey};
+use libcrux_curve25519::hacl::scalarmult;
+use libcrux_kem::MlKem768;
+use libcrux_traits::kem::secrets::Kem;
+use rand::RngCore;
+use rand::rngs::StdRng;
+use rand_core::CryptoRng;
+use rand_core::SeedableRng;
+use crate::primitives::dh_akem::generate_dh_akem_keypair;
+use crate::primitives::mlkem::generate_mlkem768_keypair;
+use crate::primitives::x25519::generate_dh_keypair;
+use crate::primitives::x25519::generate_random_scalar;
+use crate::primitives::xwing::generate_xwing_keypair;
+use crate::primitives::{decrypt_message_id, encrypt_message_id};
+use alloc::{format, vec::Vec};
+use wasm_bindgen::prelude::*;
+
+const HPKE_PSK_ID: &[u8] = b"PSK_INFO_ID_TAG"; // Spec requires a tag
+const HPKE_INFO: &[u8] = b"";
+const HPKE_AAD: &[u8] = b"";
+
+// Key lengths
+const LEN_DHKEM_ENCAPS_KEY: usize = libcrux_curve25519::EK_LEN;
+const LEN_DHKEM_DECAPS_KEY: usize = libcrux_curve25519::DK_LEN;
+const LEN_DHKEM_SHAREDSECRET_ENCAPS: usize = libcrux_curve25519::SS_LEN;
+const LEN_DHKEM_SHARED_SECRET: usize = libcrux_curve25519::SS_LEN;
+const LEN_DH_ITEM: usize = LEN_DHKEM_DECAPS_KEY;
+
+// https://openquantumsafe.org/liboqs/algorithms/kem/ml-kem.html
+// todo, source from crates instead of hardcoding
+const LEN_MLKEM_ENCAPS_KEY: usize = 1184;
+const LEN_MLKEM_DECAPS_KEY: usize = 2400;
+const LEN_MLKEM_SHAREDSECRET_ENCAPS: usize = 1088;
+const LEN_MLKEM_SHAREDSECRET: usize = 32;
+const LEN_MLKEM_RAND_SEED_SIZE: usize = 64;
+
+// https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/#name-encoding-and-sizes
+const LEN_XWING_ENCAPS_KEY: usize = 1216;
+const LEN_XWING_DECAPS_KEY: usize = 32;
+const LEN_XWING_SHAREDSECRET_ENCAPS: usize = 1120;
+const LEN_XWING_SHAREDSECRET: usize = 32;
+const LEN_XWING_RAND_SEED_SIZE: usize = 96;
+
+// "Metadata" aka sender pubkey and encapsulated secrets
+const METADATA_LENGTH: usize =
+    LEN_DH_ITEM + LEN_MLKEM_SHAREDSECRET_ENCAPS + LEN_DHKEM_SHAREDSECRET_ENCAPS;
+
+// Message ID (uuid) and KMID
+const LEN_MESSAGE_ID: usize = 16;
+// TODO: this will be aes-gcm and use AES GCM TagSize
+// TODO: current implementation prepends the nonce to the encrypted message.
+// Recheck this when switching implementations.
+const LEN_KMID: usize =
+    libcrux_chacha20poly1305::TAG_LEN + libcrux_chacha20poly1305::NONCE_LEN + LEN_MESSAGE_ID;
+
+#[derive(Debug)]
+pub struct Envelope {
+    cmessage: Vec<u8>,
+    cmetadata: Vec<u8>,
+    metadata_encap: [u8; LEN_XWING_SHAREDSECRET_ENCAPS],
+    mgdh_pubkey: [u8; LEN_DH_ITEM],
+    mgdh: [u8; LEN_DH_ITEM],
+}
+
+// TODO: plaintext structure/types
+#[derive(Debug)]
+pub struct Plaintext {
+    msg: Vec<u8>,
+    recipient_pubkey_dhakem: Option<Vec<u8>>,
+    sender_reply_pubkey_dhakem: Option<Vec<u8>>,
+    sender_reply_pubkey_pq_psk: Option<Vec<u8>>,
+    sender_reply_pubkey_hybrid: Option<Vec<u8>>,
+}
+
+/// Represent stored ciphertexts on the server
+pub struct ServerMessageStore {
+    message_id: [u8; LEN_MESSAGE_ID],
+    envelope: Envelope,
+}
+
+pub struct FetchResponse {
+    enc_id: [u8; LEN_KMID],   // aka kmid
+    pmgdh: [u8; LEN_DH_ITEM], // aka per-request clue
+}
+
+impl FetchResponse {
+    pub fn new(enc_id: [u8; LEN_KMID], pmgdh: [u8; LEN_DH_ITEM]) -> Self {
+        Self {
+            enc_id: enc_id,
+            pmgdh: pmgdh,
+        }
+    }
+}
+
+// Plaintext metadata
+pub struct Metadata {
+    pub sender_pubkey_bytes: [u8; LEN_DH_ITEM],
+    pub pq_psk_ss_encaps: [u8; LEN_MLKEM_SHAREDSECRET_ENCAPS],
+    pub dhakem_ss_encaps: [u8; LEN_DHKEM_SHAREDSECRET_ENCAPS],
+}
+
+// TODO: NOT FOR PROD, parsing untrusted ct
+impl Metadata {
+    /// Serialize Metadata.
+    /// [0:LEN_DHKEM_ENCAPS_KEY] is sender pubkey
+    /// [LEN_DHKEM_ENCAPS_KEY:LEN_DHKEM_ENCAPS_KEY+LEN_MLKEM_SS_ENCAPS] is PSK encaps
+    /// [LEN_DHKEM_ENCAPS_KEY+LEN_MLKEM_SS_ENCAPS:] is dh-akem enc encaps
+    /// Order may change in final version
+    pub fn to_bytes(&self) -> [u8; METADATA_LENGTH] {
+        let mut bytes = [0u8; METADATA_LENGTH];
+        bytes[0..LEN_DHKEM_ENCAPS_KEY].copy_from_slice(&self.sender_pubkey_bytes);
+        bytes[LEN_DHKEM_ENCAPS_KEY..LEN_DHKEM_ENCAPS_KEY + LEN_MLKEM_SHAREDSECRET_ENCAPS]
+            .copy_from_slice(&self.pq_psk_ss_encaps);
+        bytes[LEN_DHKEM_ENCAPS_KEY + LEN_MLKEM_SHAREDSECRET_ENCAPS..]
+            .copy_from_slice(&self.dhakem_ss_encaps);
+        bytes
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for Metadata {
+    type Error = &'static str;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != METADATA_LENGTH {
+            return Err("Metadata length error");
+        }
+
+        let sender_pubkey_bytes = bytes[0..LEN_DHKEM_ENCAPS_KEY]
+            .try_into()
+            .expect("Metadata slice -> array error [0:32]");
+        let pq_psk_end = LEN_DHKEM_ENCAPS_KEY + LEN_MLKEM_SHAREDSECRET_ENCAPS;
+        let pq_psk_ss_encaps = bytes[LEN_DHKEM_ENCAPS_KEY..pq_psk_end]
+            .try_into()
+            .expect("Metadata slice -> array error [32:32+1088]");
+        let dhakem_ss_encaps = bytes[pq_psk_end..]
+            .try_into()
+            .expect("Metadata slice -> array error [32+1088:]");
+
+        Ok(Metadata {
+            sender_pubkey_bytes,
+            pq_psk_ss_encaps,
+            dhakem_ss_encaps,
+        })
+    }
+}
+
+impl From<[u8; METADATA_LENGTH]> for Metadata {
+    fn from(bytes: [u8; METADATA_LENGTH]) -> Self {
+        Metadata::try_from(&bytes[..]).expect("Need valid array length")
+    }
+}
+
+pub trait User {
+    // msg enc classical
+    fn get_dhakem_sk(&self) -> &[u8; LEN_DH_ITEM];
+    fn get_dhakem_pk(&self) -> &[u8; LEN_DH_ITEM];
+
+    // msg enc pq psk
+    fn get_pq_kem_psk_pk(&self) -> &[u8; LEN_MLKEM_ENCAPS_KEY];
+    fn get_pq_kem_psk_sk(&self) -> &[u8; LEN_MLKEM_DECAPS_KEY];
+
+    // md enc hybrid
+    fn get_hybrid_md_pk(&self) -> &[u8; LEN_XWING_ENCAPS_KEY];
+    fn get_hybrid_md_sk(&self) -> &[u8; LEN_XWING_DECAPS_KEY];
+
+    // fetch classical
+    fn get_fetch_sk(&self) -> &[u8; LEN_DH_ITEM];
+    fn get_fetch_pk(&self) -> &[u8; LEN_DH_ITEM];
+}
+
+pub fn hpke_keypair_from_bytes(sk_bytes: &[u8], pk_bytes: &[u8]) -> HpkeKeyPair {
+    HpkeKeyPair::from((sk_bytes, pk_bytes))
+}
+
+pub fn hpke_pubkey_from_bytes(pk_bytes: &[u8]) -> HpkePublicKey {
+    HpkePublicKey::from(pk_bytes)
+}
+
+pub fn encrypt<R: RngCore + CryptoRng>(
+    rng: &mut R,
+    sender: &dyn User,
+    plaintext: &[u8],
+    recipient: &dyn User,
+) -> Envelope {
+    use hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305;
+    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+    use hpke_rs::{Hpke, Mode};
+
+    // TODO: AESGCM instead
+    let mut hpke_authenc: Hpke<HpkeLibcrux> =
+        Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
+
+    let mut hpke_metadata: Hpke<HpkeLibcrux> =
+        Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, ChaCha20Poly1305);
+
+    let recipient_dhakem_pubkey = hpke_pubkey_from_bytes(recipient.get_dhakem_pk());
+
+    let sender_hpke_keypair =
+        hpke_keypair_from_bytes(sender.get_dhakem_sk(), sender.get_dhakem_pk());
+
+    // Note: Don't need SEED_GEN len randomness (64), just SHARED_SECRET len (32),
+    // according to MLK-KEM source code.
+    let mut randomness: [u8; LEN_MLKEM_SHAREDSECRET] = [0u8; LEN_MLKEM_SHAREDSECRET];
+    StdRng::seed_from_u64(0).fill_bytes(&mut randomness);
+
+    // Calculate PQ PSK - encapsulate to the recipient's key
+    let (psk, psk_ct) =
+        MlKem768::encaps(recipient.get_pq_kem_psk_pk(), &randomness).expect("PSK encaps failed");
+
+    // HPKE AuthPSK message encryption
+    let (mesage_dhakem_shared_secret_encaps, message_ciphertext) = hpke_authenc
+        .seal(
+            &recipient_dhakem_pubkey,
+            HPKE_INFO,
+            HPKE_AAD,
+            plaintext,
+            Some(&psk),
+            Some(HPKE_PSK_ID),                       // Fixed PSK ID
+            Some(sender_hpke_keypair.private_key()), // sender DH-AKEM private key
+        )
+        .unwrap();
+
+    // Create mgdh (message clue) with a DH agreement between an ephemeral curve25519 keypair
+    // and the recipient's Fetching key
+    let eph_sk: [u8; LEN_DH_ITEM] =
+        generate_random_scalar(rng).expect("DH keygen (ephemeral fetch) failed!");
+    let mut eph_pk: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+    libcrux_curve25519::secret_to_public(&mut eph_pk, &eph_sk);
+    let mut mgdh = [0u8; LEN_DH_ITEM];
+    let _ = scalarmult(&mut mgdh, &eph_sk, recipient.get_fetch_pk());
+
+    // Serialize sender Dh-AKEM pubkey for Metadata
+    let mut sender_pubkey_bytes: [u8; LEN_DHKEM_ENCAPS_KEY] = [0u8; LEN_DHKEM_ENCAPS_KEY];
+    sender_pubkey_bytes.copy_from_slice(sender_hpke_keypair.public_key().as_slice());
+
+    let dhakem_ss_encaps: [u8; LEN_DH_ITEM] = mesage_dhakem_shared_secret_encaps
+        .try_into()
+        .expect(&format!("Need {} bytes", LEN_DH_ITEM));
+
+    // Build Plaintext metadata
+    let metadata_bytes = Metadata {
+        sender_pubkey_bytes: sender_pubkey_bytes,
+        pq_psk_ss_encaps: psk_ct,
+        dhakem_ss_encaps: dhakem_ss_encaps,
+    }
+    .to_bytes();
+
+    // Serialize then encrypt metadata with metadata key (xwing) and Hpke Base mode
+    let recipient_md_pubkey = hpke_pubkey_from_bytes(recipient.get_hybrid_md_pk());
+
+    let (md_ss_encaps_vec, metadata_ciphertext) = hpke_metadata
+        .seal(
+            &recipient_md_pubkey,
+            HPKE_INFO,
+            HPKE_AAD,
+            &metadata_bytes,
+            None,
+            None,
+            None,
+        )
+        .expect("Expected Hpke.BaseMode sealed ciphertext");
+
+    let metadata_ss_encaps: [u8; LEN_XWING_SHAREDSECRET_ENCAPS] =
+        md_ss_encaps_vec.try_into().expect(&format!(
+            "Need {} byte encapsulated shared secret",
+            LEN_XWING_SHAREDSECRET_ENCAPS
+        ));
+
+    Envelope {
+        cmessage: message_ciphertext,
+        cmetadata: metadata_ciphertext,
+        metadata_encap: metadata_ss_encaps,
+        mgdh_pubkey: eph_pk,
+        mgdh: mgdh,
+    }
+}
+
+pub fn decrypt(receiver: &dyn User, envelope: &Envelope) -> Plaintext {
+    use hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305;
+    use hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256;
+    use hpke_rs::hpke_types::KemAlgorithm::{DhKem25519, XWingDraft06};
+    use hpke_rs::{Hpke, Mode};
+
+    let hpke_authenc: Hpke<HpkeLibcrux> =
+        Hpke::new(Mode::AuthPsk, DhKem25519, HkdfSha256, ChaCha20Poly1305);
+
+    let hpke_base: Hpke<HpkeLibcrux> =
+        Hpke::new(Mode::Base, XWingDraft06, HkdfSha256, ChaCha20Poly1305);
+
+    let receiver_metadata_keypair =
+        hpke_keypair_from_bytes(receiver.get_hybrid_md_sk(), receiver.get_hybrid_md_pk());
+
+    let receiver_dhakem_keypair =
+        hpke_keypair_from_bytes(receiver.get_dhakem_sk(), receiver.get_dhakem_pk());
+
+    let raw_metadata = hpke_base
+        .open(
+            &envelope.metadata_encap,
+            receiver_metadata_keypair.private_key(),
+            HPKE_INFO,
+            HPKE_AAD,
+            &envelope.cmetadata,
+            None,
+            None,
+            None,
+        )
+        .expect("Wanted decrypted metadata");
+
+    let raw_md_bytes: [u8; METADATA_LENGTH] =
+        raw_metadata.try_into().expect("Need METADATA_LENGTH array");
+    let metadata = Metadata::try_from(raw_md_bytes).unwrap();
+
+    let hpke_pubkey_sender = hpke_pubkey_from_bytes(&metadata.sender_pubkey_bytes);
+
+    let psk = MlKem768::decaps(&metadata.pq_psk_ss_encaps, receiver.get_pq_kem_psk_sk()).unwrap();
+
+    let pt = hpke_authenc
+        .open(
+            &metadata.dhakem_ss_encaps,
+            receiver_dhakem_keypair.private_key(),
+            HPKE_INFO,
+            HPKE_AAD,
+            &envelope.cmessage,
+            Some(&psk),
+            Some(HPKE_PSK_ID),
+            Some(&hpke_pubkey_sender),
+        )
+        .expect("Decryption failed");
+
+    // TODO parse
+    Plaintext {
+        msg: pt,
+        recipient_pubkey_dhakem: None,
+        sender_reply_pubkey_dhakem: None,
+        sender_reply_pubkey_pq_psk: None,
+        sender_reply_pubkey_hybrid: None,
+    }
+}
+
+/// Given a set of ciphertext bundles (C, X, Z) and their associated uuid (ServerMessageStore),
+/// compute a fixed-length set of "challenges" >= the number of SeverMessageStore entries.
+/// A challenge is returned as a tuple of DH agreement outputs (or random data tuples of the same length).
+/// For benchmarking purposes, supply the rng as a separable parameter, and allow the total number of expected responses to be specified as a paremeter (worst case performance
+/// when the number of items in the server store approaches num total_responses.)
+pub fn compute_fetch_challenges<R: RngCore + CryptoRng>(
+    rng: &mut R,
+    store: &[ServerMessageStore],
+    total_responses: usize,
+) -> Vec<FetchResponse> {
+    let mut responses = Vec::with_capacity(total_responses);
+
+    // Generate ephemeral (per request) keypair
+    let (eph_sk, _eph_pk) = generate_dh_keypair(&mut *rng).expect("Wanted DH keypair");
+    let eph_sk_bytes = eph_sk.clone().into_bytes();
+
+    for entry in store.iter() {
+        let message_id = &entry.message_id;
+
+        // 3-party DH yields shared_secret used to encrypt message_id
+        let mut shared_secret: [u8; LEN_DHKEM_SHARED_SECRET] = [0u8; LEN_DHKEM_SHARED_SECRET];
+        let _ = scalarmult(&mut shared_secret, &eph_sk_bytes, &entry.envelope.mgdh);
+        let enc_mid = encrypt_message_id(&shared_secret, message_id).unwrap();
+
+        let kmid = enc_mid
+            .try_into()
+            .expect(&format!("Need {} bytes", LEN_KMID));
+
+        // 2-party DH yields per-request clue (pmgdh) used by intended recipient
+        // to compute shared_secret
+        let mut pmgdh: [u8; LEN_DHKEM_SHARED_SECRET] = [0u8; LEN_DHKEM_SHARED_SECRET];
+        let _ = scalarmult(&mut pmgdh, &eph_sk_bytes, &entry.envelope.mgdh_pubkey);
+
+        responses.push(FetchResponse {
+            enc_id: kmid,
+            pmgdh: pmgdh,
+        });
+
+        // Are we done?
+        if responses.len() == total_responses {
+            break;
+        }
+    }
+
+    // Pad if needed to return fixed length of responses
+    while responses.len() < total_responses {
+        let mut pad_kmid: [u8; LEN_KMID] = [0u8; LEN_KMID];
+        rng.fill_bytes(&mut pad_kmid);
+
+        let mut pad_pmgdh: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+        rng.fill_bytes(&mut pad_pmgdh);
+
+        responses.push(FetchResponse {
+            enc_id: pad_kmid,
+            pmgdh: pad_pmgdh,
+        });
+    }
+    responses
+}
+
+/// Solve fetch challenges (encrypted message IDs) and return array of valid message_ids.
+/// TODO: For simplicity, serialize/deserialize is skipped
+pub fn solve_fetch_challenges(
+    recipient: &dyn User,
+    challenges: Vec<FetchResponse>,
+) -> Vec<Vec<u8>> {
+    // TODO: Message IDs are probably uuids of type [u8; 16]
+    let mut message_ids: Vec<Vec<u8>> = Vec::new();
+
+    for chall in challenges.iter() {
+        // Compute 3-party DH on the pmgdh
+        let mut maybe_kmid_secret: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+        let _ = scalarmult(
+            &mut maybe_kmid_secret,
+            recipient.get_fetch_sk(),
+            &chall.pmgdh,
+        );
+
+        // Try using the output for decryption
+        let maybe_message_id = decrypt_message_id(&maybe_kmid_secret, &chall.enc_id);
+
+        if let Ok(message_id) = maybe_message_id {
+            message_ids.push(message_id);
+        }
+    }
+    message_ids
+}
+
+pub struct Source {
+    sk_dh: [u8; LEN_DHKEM_DECAPS_KEY],
+    pk_dh: [u8; LEN_DHKEM_ENCAPS_KEY],
+    sk_pqkem_psk: [u8; LEN_MLKEM_DECAPS_KEY],
+    pk_pqkem_psk: [u8; LEN_MLKEM_ENCAPS_KEY],
+    sk_md: [u8; LEN_XWING_DECAPS_KEY],
+    pk_md: [u8; LEN_XWING_ENCAPS_KEY],
+    sk_fetch: [u8; LEN_DH_ITEM],
+    pk_fetch: [u8; LEN_DH_ITEM],
+}
+
+impl Source {
+    /// This doesn't use keys bootstrapped from a passphrase;
+    /// for now it's the same as journalist setup
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let (sk_dh, pk_dh) = generate_dh_akem_keypair(rng).expect("DH keygen (DH-AKEM) failed");
+
+        let mut pk_fetch: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+        let mut sk_fetch: [u8; LEN_DHKEM_DECAPS_KEY] =
+            generate_random_scalar(rng).expect("DH keygen (Fetching) failed!");
+        let _ = libcrux_curve25519::secret_to_public(&mut sk_fetch, &mut pk_fetch);
+
+        let (sk_pqkem_psk, pk_pqkem_psk) =
+            generate_mlkem768_keypair(rng).expect("Failed to generate ml-kem keys!");
+
+        let (sk_md, pk_md) = generate_xwing_keypair(rng).expect("Failed to generate xwing keys");
+        Self {
+            sk_dh: *sk_dh.as_bytes(),
+            pk_dh: *pk_dh.as_bytes(),
+            sk_pqkem_psk: *sk_pqkem_psk.as_bytes(),
+            pk_pqkem_psk: *pk_pqkem_psk.as_bytes(),
+            sk_md: *sk_md.as_bytes(),
+            pk_md: *pk_md.as_bytes(),
+            sk_fetch: sk_fetch,
+            pk_fetch: pk_fetch,
+        }
+    }
+}
+
+impl User for Source {
+    fn get_dhakem_sk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.sk_dh
+    }
+    fn get_dhakem_pk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.pk_dh
+    }
+    fn get_fetch_sk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.sk_fetch
+    }
+    fn get_fetch_pk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.pk_fetch
+    }
+    fn get_hybrid_md_pk(&self) -> &[u8; LEN_XWING_ENCAPS_KEY] {
+        &self.pk_md
+    }
+    fn get_hybrid_md_sk(&self) -> &[u8; LEN_XWING_DECAPS_KEY] {
+        &self.sk_md
+    }
+    fn get_pq_kem_psk_pk(&self) -> &[u8; LEN_MLKEM_ENCAPS_KEY] {
+        &self.pk_pqkem_psk
+    }
+    fn get_pq_kem_psk_sk(&self) -> &[u8; LEN_MLKEM_DECAPS_KEY] {
+        &self.sk_pqkem_psk
+    }
+}
+
+pub struct Journalist {
+    sk_dh: [u8; LEN_DHKEM_DECAPS_KEY],
+    pk_dh: [u8; LEN_DHKEM_ENCAPS_KEY],
+    sk_pqkem_psk: [u8; LEN_MLKEM_DECAPS_KEY],
+    pk_pqkem_psk: [u8; LEN_MLKEM_ENCAPS_KEY],
+    sk_md: [u8; LEN_XWING_DECAPS_KEY],
+    pk_md: [u8; LEN_XWING_ENCAPS_KEY],
+    sk_fetch: [u8; LEN_DH_ITEM],
+    pk_fetch: [u8; LEN_DH_ITEM],
+}
+
+impl Journalist {
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let (sk_dh, pk_dh) = generate_dh_akem_keypair(rng).expect("DH keygen (DH-AKEM) failed");
+
+        let mut pk_fetch: [u8; LEN_DH_ITEM] = [0u8; LEN_DH_ITEM];
+        let mut sk_fetch: [u8; LEN_DHKEM_DECAPS_KEY] =
+            generate_random_scalar(rng).expect("DH keygen (Fetching) failed!");
+        let _ = libcrux_curve25519::secret_to_public(&mut sk_fetch, &mut pk_fetch);
+
+        let (sk_pqkem_psk, pk_pqkem_psk) =
+            generate_mlkem768_keypair(rng).expect("Failed to generate ml-kem keys!");
+
+        let (sk_md, pk_md) = generate_xwing_keypair(rng).expect("Failed to generate xwing keys");
+        Self {
+            sk_dh: *sk_dh.as_bytes(),
+            pk_dh: *pk_dh.as_bytes(),
+            sk_pqkem_psk: *sk_pqkem_psk.as_bytes(),
+            pk_pqkem_psk: *pk_pqkem_psk.as_bytes(),
+            sk_md: *sk_md.as_bytes(),
+            pk_md: *pk_md.as_bytes(),
+            sk_fetch: sk_fetch,
+            pk_fetch: pk_fetch,
+        }
+    }
+}
+
+impl User for Journalist {
+    fn get_dhakem_sk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.sk_dh
+    }
+    fn get_dhakem_pk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.pk_dh
+    }
+    fn get_fetch_sk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.sk_fetch
+    }
+    fn get_fetch_pk(&self) -> &[u8; LEN_DH_ITEM] {
+        &self.pk_fetch
+    }
+    fn get_hybrid_md_pk(&self) -> &[u8; LEN_XWING_ENCAPS_KEY] {
+        &self.pk_md
+    }
+    fn get_hybrid_md_sk(&self) -> &[u8; LEN_XWING_DECAPS_KEY] {
+        &self.sk_md
+    }
+    fn get_pq_kem_psk_pk(&self) -> &[u8; LEN_MLKEM_ENCAPS_KEY] {
+        &self.pk_pqkem_psk
+    }
+    fn get_pq_kem_psk_sk(&self) -> &[u8; LEN_MLKEM_DECAPS_KEY] {
+        &self.sk_pqkem_psk
+    }
+}
+
+// Begin unit tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(666); // obvi
+        let sender = Source::new(&mut rng);
+        let recipient = Journalist::new(&mut rng);
+        let plaintext = b"Encrypt-decrypt test".to_vec();
+
+        let envelope = encrypt(&mut rng, &sender, &plaintext, &recipient);
+        let decrypted = decrypt(&recipient, &envelope);
+
+        assert_eq!(decrypted.msg, plaintext);
+        // TODO: Add more fields to plaintext, and add assertions
+    }
+
+}
+
+// Begin benchmark functions
+
+pub fn setup() -> (Source, Journalist, Vec<u8>, Envelope) {
+    let source = Source::new(&mut StdRng::seed_from_u64(666));
+    let journalist = Journalist::new(&mut StdRng::seed_from_u64(666));
+    let plaintext = b"super secret msg".to_vec();
+    let envelope = encrypt(
+        &mut StdRng::seed_from_u64(666),
+        &source,
+        &plaintext,
+        &journalist,
+    );
+    (source, journalist, plaintext, envelope)
+}
+
+/// Run the encrypt/decrypt/fetch benchmark loop `iterations` times.
+///
+/// This executes the same operations that were previously benchmarked
+/// with Criterion, making it possible to invoke from native code or
+/// WebAssembly environments.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn encrypt_decrypt_bench(iterations: u32) {
+    let (source, journalist, plaintext, envelope) = setup();
+
+    let mut rng_fetch = StdRng::seed_from_u64(8888);
+    let mut store = Vec::new();
+    for i in 0..100 {
+        let env = encrypt(
+            &mut rng_fetch,
+            &source,
+            format!("msg {i}").as_bytes(),
+            &journalist,
+        );
+        let message_id = [i as u8; LEN_MESSAGE_ID];
+        store.push(ServerMessageStore {
+            message_id,
+            envelope: env,
+        });
+    }
+
+    for _ in 0..iterations {
+        let env = encrypt(
+            &mut StdRng::seed_from_u64(666),
+            &source,
+            &plaintext,
+            &journalist,
+        );
+        let _ = decrypt(&journalist, &env);
+
+        let challenges = compute_fetch_challenges(&mut rng_fetch, &store, 150);
+        let _ = solve_fetch_challenges(&journalist, challenges);
+    }
+
+    let _ = envelope; // silence unused variable warning
+}

--- a/securedrop-protocol/src/bench/mod.rs
+++ b/securedrop-protocol/src/bench/mod.rs
@@ -1,0 +1,5 @@
+pub mod encrypt_decrypt;
+pub mod submit;
+
+pub use encrypt_decrypt::encrypt_decrypt_bench;
+pub use submit::submit_bench;

--- a/securedrop-protocol/src/bench/submit.rs
+++ b/securedrop-protocol/src/bench/submit.rs
@@ -1,0 +1,87 @@
+use rand::{SeedableRng, rngs::StdRng};
+use alloc::{vec, vec::Vec};
+
+use crate::{
+    journalist::JournalistClient, keys::FPFKeyPair, messages::core::SourceJournalistKeyResponse,
+    server::Server, source::SourceClient,
+};
+use wasm_bindgen::prelude::*;
+
+fn setup_test_environment() -> (SourceClient, Vec<SourceJournalistKeyResponse>) {
+    // 1. Create server with newsroom and journalist
+    let mut server = Server::new();
+
+    // 2. Setup newsroom
+    let newsroom_setup_request = server
+        .create_newsroom_setup_request(StdRng::seed_from_u64(666))
+        .expect("Can create newsroom setup request");
+
+    // Store the newsroom verifying key before moving the request
+    let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
+
+    // Simulate FPF signing
+    let fpf_keypair = FPFKeyPair::new(StdRng::seed_from_u64(666));
+    let newsroom_setup_response = newsroom_setup_request
+        .sign(&fpf_keypair)
+        .expect("Can sign newsroom setup request");
+
+    server.set_fpf_signature(newsroom_setup_response.sig);
+
+    // 3. Setup journalist
+    let mut journalist = JournalistClient::new();
+    let journalist_setup_request = journalist
+        .create_setup_request(StdRng::seed_from_u64(666))
+        .expect("Can create journalist setup request");
+
+    server
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // 4. Journalist provides ephemeral keys
+    let ephemeral_key_request = journalist
+        .create_ephemeral_key_request(StdRng::seed_from_u64(666))
+        .expect("Can create ephemeral key request");
+
+    server
+        .handle_ephemeral_key_request(ephemeral_key_request)
+        .expect("Can handle ephemeral key request");
+
+    // 5. Generate source session from passphrase
+    let mut source = SourceClient::from_passphrase(&[1u8; 32]);
+
+    // 6. Source fetches newsroom keys
+    let newsroom_key_request = source.fetch_newsroom_keys();
+    let newsroom_key_response = server.handle_source_newsroom_key_request(newsroom_key_request);
+
+    // Source handles and verifies the newsroom key response
+    source
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .expect("Newsroom key response should be valid");
+
+    // 7. Source fetches journalist keys
+    let journalist_key_request = source.fetch_journalist_keys();
+    let journalist_key_responses = server.handle_source_journalist_key_request(
+        journalist_key_request,
+        &mut StdRng::seed_from_u64(666),
+    );
+
+    // Source handles and verifies the journalist key response
+    source
+        .handle_journalist_key_response(&journalist_key_responses[0], &newsroom_verifying_key)
+        .expect("Journalist key response should be valid");
+
+    (source, journalist_key_responses)
+}
+
+/// Run the submit benchmark loop `iterations` times.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn submit_bench(iterations: u32) {
+    for _ in 0..iterations {
+        let (source, journalist_key_responses) = setup_test_environment();
+        let test_message = vec![0u8; 512];
+        let mut rng = StdRng::seed_from_u64(666);
+        source
+            .submit_message(test_message, &journalist_key_responses, &mut rng)
+            .expect("Message submission should succeed");
+    }
+}

--- a/securedrop-protocol/src/client.rs
+++ b/securedrop-protocol/src/client.rs
@@ -1,0 +1,142 @@
+use crate::messages::core::{
+    Message, MessageChallengeFetchRequest, MessageChallengeFetchResponse, MessageFetchResponse,
+};
+use alloc::vec::Vec;
+use anyhow::Error;
+use rand_core::{CryptoRng, RngCore};
+use uuid::Uuid;
+
+/// Trait for structured messages that can be serialized for encryption
+pub trait StructuredMessage {
+    /// Serialize the message into bytes for padding and encryption
+    fn into_bytes(self) -> Vec<u8>;
+}
+
+/// Internal trait for private key access - not to be exposed
+pub(crate) trait ClientPrivate {
+    /// Get the fetching private key for message ID decryption
+    fn fetching_private_key(&self) -> Result<[u8; 32], Error>;
+}
+
+/// Common client functionality for source and journalist clients
+pub trait Client {
+    /// Associated type for the newsroom key
+    type NewsroomKey;
+
+    /// Get the newsroom's verifying key
+    fn newsroom_verifying_key(&self) -> Option<&Self::NewsroomKey>;
+
+    /// Store the newsroom's verifying key
+    fn set_newsroom_verifying_key(&mut self, key: Self::NewsroomKey);
+
+    /// Get the newsroom's verifying key, returning an error if not available
+    fn get_newsroom_verifying_key(&self) -> Result<&Self::NewsroomKey, Error> {
+        self.newsroom_verifying_key()
+            .ok_or_else(|| anyhow::anyhow!("Newsroom verifying key not available"))
+    }
+
+    /// Fetch message IDs (step 7)
+    fn fetch_message_ids<R: RngCore + CryptoRng>(
+        &self,
+        rng: &mut R,
+    ) -> MessageChallengeFetchRequest;
+
+    /// Process message ID fetch response (step 7)
+    fn process_message_id_response(
+        &self,
+        response: &MessageChallengeFetchResponse,
+    ) -> Result<Vec<Uuid>, Error>
+    where
+        Self: ClientPrivate,
+    {
+        let mut message_ids = Vec::new();
+        let fetching_private_key = self.fetching_private_key()?;
+
+        // Process each (Q_i, cid_i) pair
+        for (q_i, cid_i) in &response.messages {
+            // k_i = DH(Q_i, U_fetch,sk)
+            let q_public_key = crate::primitives::x25519::dh_public_key_from_scalar(
+                q_i.clone().try_into().unwrap_or([0u8; 32]),
+            );
+            let k_i =
+                crate::primitives::x25519::dh_shared_secret(&q_public_key, fetching_private_key)?
+                    .into_bytes();
+
+            // Decrypt message ID: id_i = Dec(k_i, cid_i)
+            match crate::primitives::decrypt_message_id(&k_i, cid_i) {
+                Ok(decrypted_id) => {
+                    // Try to parse as UUID
+                    if decrypted_id.len() == 16 {
+                        if let Ok(id_bytes) = decrypted_id.try_into() {
+                            let uuid = Uuid::from_bytes(id_bytes);
+                            message_ids.push(uuid);
+                        }
+                    }
+                }
+                Err(_) => {
+                    // Decryption failed, this is a random entry
+                }
+            }
+        }
+
+        Ok(message_ids)
+    }
+
+    /// Fetch a specific message (step 8)
+    fn fetch_message(&self, _message_id: Uuid) -> Option<MessageFetchResponse> {
+        unimplemented!("")
+    }
+
+    /// Submit a structured message (step 6 for sources, step 9 for journalists)
+    ///
+    /// This is a generic method that handles both source message submission and journalist replies.
+    /// The specific message structure and encryption details are provided by the implementing types.
+    fn submit_structured_message<M, R>(
+        &self,
+        message: M,
+        recipient_ephemeral_keys: (
+            &crate::primitives::x25519::DHPublicKey,
+            &crate::primitives::PPKPublicKey,
+        ),
+        recipient_pke_key: &crate::primitives::PPKPublicKey,
+        recipient_fetch_key: &crate::primitives::x25519::DHPublicKey,
+        sender_dh_private_key: &crate::primitives::x25519::DHPrivateKey,
+        sender_dh_public_key: &crate::primitives::x25519::DHPublicKey,
+        rng: &mut R,
+    ) -> Result<Message, Error>
+    where
+        M: StructuredMessage,
+        R: RngCore + CryptoRng,
+    {
+        // 1. Create the padded message
+        let padded_message = crate::primitives::pad::pad_message(&message.into_bytes());
+
+        // 2. Perform authenticated encryption
+        let ((c1, c2), c_double_prime) = crate::primitives::auth_encrypt(
+            sender_dh_private_key,
+            recipient_ephemeral_keys,
+            &padded_message,
+        )?;
+
+        // 3. Encrypt the DH key and ciphertexts
+        let c_prime = crate::primitives::enc(recipient_pke_key, sender_dh_public_key, &c1, &c2)?;
+
+        // 4. Combine ciphertexts
+        let ciphertext = [c_prime, c_double_prime].concat();
+
+        // 5. Generate DH shares for message ID encryption
+        let x_bytes = crate::primitives::x25519::generate_random_scalar(rng)
+            .map_err(|e| anyhow::anyhow!("Failed to generate random scalar: {}", e))?;
+        let x_share = crate::primitives::x25519::dh_public_key_from_scalar(x_bytes);
+        let z_share = crate::primitives::x25519::dh_shared_secret(recipient_fetch_key, x_bytes)?;
+
+        // 6. Create message submit request
+        let request = Message {
+            ciphertext,
+            dh_share_z: z_share.into_bytes().to_vec(),
+            dh_share_x: x_share.into_bytes().to_vec(),
+        };
+
+        Ok(request)
+    }
+}

--- a/securedrop-protocol/src/journalist.rs
+++ b/securedrop-protocol/src/journalist.rs
@@ -1,0 +1,226 @@
+//! Journalist-side protocol implementation
+//!
+//! This module implements the journalist-side handling of SecureDrop protocol steps 7-9.
+use alloc::vec::Vec;
+use anyhow::Error;
+use rand_core::{CryptoRng, RngCore};
+use uuid::Uuid;
+
+use crate::keys::{
+    JournalistDHKeyPair, JournalistEphemeralDHKeyPair, JournalistEphemeralKEMKeyPair,
+    JournalistOneTimeKeyBundle, JournalistEphemeralPKEKeyPair, JournalistFetchKeyPair,
+    JournalistOneTimePublicKeys, JournalistSigningKeyPair,
+};
+use crate::keys::{JournalistEnrollmentKeyBundle, SourcePublicKeys};
+use crate::messages::core::{JournalistReplyMessage, Message, MessageChallengeFetchRequest};
+use crate::messages::setup::{JournalistRefreshRequest, JournalistSetupRequest};
+use crate::primitives::x25519::DHPublicKey;
+use crate::primitives::{
+    generate_dh_akem_keypair, generate_mlkem768_keypair, generate_xwing_keypair,
+};
+use crate::sign::VerifyingKey;
+use crate::{Client, client::ClientPrivate};
+
+/// Journalist session for interacting with the server
+///
+/// TODO: All this stuff should be persisted to disk.
+#[derive(Default)]
+pub struct JournalistClient {
+    /// Journalist's long-term signing key pair
+    signing_key: Option<JournalistSigningKeyPair>,
+    /// Journalist's long-term fetching key pair
+    fetching_key: Option<JournalistFetchKeyPair>,
+    /// Journalist's long-term DH key pair
+    /// TODO: Remove
+    dh_key: Option<JournalistDHKeyPair>,
+    /// Generated ephemeral key pairs (for reuse)
+    ephemeral_keys: Vec<JournalistOneTimeKeyBundle>,
+    /// Newsroom's verifying key
+    newsroom_verifying_key: Option<VerifyingKey>,
+}
+
+impl JournalistClient {
+    /// Create a new journalist session
+    ///
+    /// TODO: Load from storage
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Generate a new journalist setup request.
+    ///
+    /// This generates the journalist's key pairs and creates a setup request
+    /// containing only the public keys to send to the newsroom.
+    ///
+    /// TODO: The caller (eventual CLI) should persist these keys to disk.
+    pub fn create_setup_request<R: RngCore + CryptoRng>(
+        &mut self,
+        mut rng: R,
+    ) -> Result<JournalistSetupRequest, Error> {
+        // Generate journalist key pairs
+        let signing_key = JournalistSigningKeyPair::new(&mut rng);
+        let fetching_key = JournalistFetchKeyPair::new(&mut rng);
+
+        // Extract public keys before moving the key pairs
+        let signing_vk = signing_key.vk;
+        let fetching_pk = fetching_key.public_key.clone();
+
+        // Store the generated keys in the session
+        self.signing_key = Some(signing_key);
+        self.fetching_key = Some(fetching_key);
+
+        // Create enrollment key bundle with public keys
+        let enrollment_key_bundle = JournalistEnrollmentKeyBundle {
+            signing_key: signing_vk,
+            fetching_key: fetching_pk,
+        };
+
+        // Create setup request with the enrollment key bundle
+        Ok(JournalistSetupRequest {
+            enrollment_key_bundle,
+        })
+    }
+
+    /// Generate a new ephemeral key refresh request.
+    ///
+    /// This generates ephemeral key pairs and creates a request containing
+    /// the ephemeral public keys signed by the journalist's signing key.
+    ///
+    /// Step 3.2 in the spec.
+    pub fn create_ephemeral_key_request<R: RngCore + CryptoRng>(
+        &mut self,
+        mut rng: R,
+    ) -> Result<JournalistRefreshRequest, Error> {
+        // Get the signing key from the session
+        let signing_key = self.signing_key.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("No signing key found in session. Call create_setup_request first.")
+        })?;
+
+        // Generate one-time key pairs for 0.3 spec
+        let (one_time_epq_sk, one_time_epq_pk) = generate_mlkem768_keypair(&mut rng)?;
+        let (one_time_epke_sk, one_time_epke_pk) = generate_dh_akem_keypair(&mut rng)?;
+        let (one_time_emd_sk, one_time_emd_pk) = generate_xwing_keypair(&mut rng)?;
+
+        // Extract public keys
+        let one_time_message_pq_pubkey = one_time_epq_pk;
+        let one_time_message_pubkey = one_time_epke_pk;
+        let one_time_metadata_pubkey = one_time_emd_pk;
+
+        // Create one-time public keys struct for signing
+        let one_time_public_keys = JournalistOneTimePublicKeys {
+            one_time_message_pq_pk: one_time_message_pq_pubkey,
+            one_time_message_pk: one_time_message_pubkey,
+            one_time_metadata_pk: one_time_metadata_pubkey,
+        };
+
+        // Create the one-time key bundle
+        let ephemeral_key_bundle = JournalistOneTimeKeyBundle {
+            public_keys: one_time_public_keys.clone(),
+            signature: signing_key.sign(&one_time_public_keys.into_bytes()),
+        };
+
+        // Store the ephemeral key bundle in the session
+        // TODO: Save private keys
+        self.ephemeral_keys.push(ephemeral_key_bundle.clone());
+
+        Ok(JournalistRefreshRequest {
+            journalist_verifying_key: signing_key.vk,
+            ephemeral_key_bundle,
+        })
+    }
+
+    /// Get the journalist's verifying key
+    pub fn verifying_key(&self) -> Option<&VerifyingKey> {
+        self.signing_key.as_ref().map(|sk| &sk.vk)
+    }
+
+    /// Get the journalist's fetching key
+    pub fn fetching_key(&self) -> Option<&DHPublicKey> {
+        self.fetching_key.as_ref().map(|fk| &fk.public_key)
+    }
+
+    /// Get the journalist's DH key
+    pub fn dh_key(&self) -> Option<&DHPublicKey> {
+        self.dh_key.as_ref().map(|dk| &dk.public_key)
+    }
+}
+
+impl Client for JournalistClient {
+    type NewsroomKey = VerifyingKey;
+
+    fn newsroom_verifying_key(&self) -> Option<&Self::NewsroomKey> {
+        self.newsroom_verifying_key.as_ref()
+    }
+
+    fn set_newsroom_verifying_key(&mut self, key: Self::NewsroomKey) {
+        self.newsroom_verifying_key = Some(key);
+    }
+
+    fn fetch_message_ids<R: RngCore + CryptoRng>(
+        &self,
+        _rng: &mut R,
+    ) -> MessageChallengeFetchRequest {
+        MessageChallengeFetchRequest {}
+    }
+}
+
+impl ClientPrivate for JournalistClient {
+    fn fetching_private_key(&self) -> Result<[u8; 32], Error> {
+        Ok(self
+            .fetching_key
+            .as_ref()
+            .expect("Fetching key in session")
+            .private_key
+            .clone()
+            .into_bytes())
+    }
+}
+
+impl JournalistClient {
+    /// Reply to a source (step 9)
+    ///
+    /// This is similar to Step 6 (source message submission) but from the journalist's perspective.
+    /// The journalist encrypts a message for a specific source using the source's public keys.
+    pub fn reply_to_source<R: RngCore + CryptoRng>(
+        &self,
+        message: Vec<u8>,
+        source_public_keys: &SourcePublicKeys,
+        source: Uuid,
+        newsroom_signature: crate::sign::Signature,
+        rng: &mut R,
+    ) -> Result<Message, Error> {
+        // Get the journalist's DH private key
+        let journalist_dh_private_key = self
+            .dh_key
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No DH key found in session"))?
+            .private_key
+            .clone();
+
+        // 1. Create the structured message according to Step 9 format:
+        // msg || S || J_sig,pk || J_fetch,pk || J_dh,pk || σ^NR || NR
+        let journalist_reply_message = JournalistReplyMessage {
+            message,
+            source,
+            journalist_sig_pk: self.signing_key.as_ref().unwrap().vk,
+            journalist_fetch_pk: self.fetching_key.as_ref().unwrap().public_key.clone(),
+            journalist_dh_pk: self.dh_key.as_ref().unwrap().public_key.clone(),
+            newsroom_signature,
+            newsroom_sig_pk: *self.get_newsroom_verifying_key()?,
+        };
+
+        // 2. Use the shared method for encryption and message creation
+        self.submit_structured_message(
+            journalist_reply_message,
+            (
+                &source_public_keys.ephemeral_dh_pk,
+                &source_public_keys.ephemeral_kem_pk,
+            ),
+            &source_public_keys.ephemeral_pke_pk,
+            &source_public_keys.fetch_pk,
+            &journalist_dh_private_key,
+            &self.dh_key.as_ref().unwrap().public_key,
+            rng,
+        )
+    }
+}

--- a/securedrop-protocol/src/keys.rs
+++ b/securedrop-protocol/src/keys.rs
@@ -1,0 +1,34 @@
+mod journalist;
+mod newsroom;
+mod source;
+
+use rand_core::{CryptoRng, RngCore};
+
+use crate::{SigningKey, VerifyingKey};
+
+/// A key pair for FPF.
+///
+/// TODO: Make the signing key private.
+pub struct FPFKeyPair {
+    pub sk: SigningKey,
+    pub vk: VerifyingKey,
+}
+
+impl FPFKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> FPFKeyPair {
+        let sk = SigningKey::new(&mut rng).unwrap();
+        let vk = sk.vk;
+        FPFKeyPair { sk, vk }
+    }
+}
+
+pub use journalist::{
+    JournalistDHKeyPair, JournalistEnrollmentKeyBundle, JournalistEphemeralDHKeyPair,
+    JournalistEphemeralKEMKeyPair, JournalistEphemeralPKEKeyPair, JournalistFetchKeyPair,
+    JournalistOneTimeKeyBundle, JournalistOneTimePublicKeys, JournalistSigningKeyPair,
+};
+pub use newsroom::NewsroomKeyPair;
+pub use source::{
+    SourceDHKeyPair, SourceFetchKeyPair, SourceKEMKeyPair, SourceKeyBundle, SourcePKEKeyPair,
+    SourcePassphrase, SourcePublicKeys,
+};

--- a/securedrop-protocol/src/keys/journalist.rs
+++ b/securedrop-protocol/src/keys/journalist.rs
@@ -1,0 +1,260 @@
+use rand_core::{CryptoRng, RngCore};
+
+use crate::primitives::mlkem::{MLKEM768PrivateKey, MLKEM768PublicKey};
+use crate::primitives::xwing::{XWingPrivateKey, XWingPublicKey};
+use crate::primitives::{
+    PPKPrivateKey, PPKPublicKey, dh_akem::DhAkemPrivateKey, dh_akem::DhAkemPublicKey,
+    x25519::DHPrivateKey, x25519::DHPublicKey,
+};
+use crate::sign::{Signature, SigningKey, VerifyingKey};
+
+/// Journalists signing key pair
+/// Signed by the newsroom
+/// Long-term, same in 0.3
+pub struct JournalistSigningKeyPair {
+    pub(crate) vk: VerifyingKey,
+    sk: SigningKey,
+}
+
+impl JournalistSigningKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistSigningKeyPair {
+        let sk = SigningKey::new(&mut rng).unwrap();
+        let vk = sk.vk;
+        JournalistSigningKeyPair { vk, sk }
+    }
+
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        self.sk.sign(message)
+    }
+
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        &self.vk
+    }
+}
+
+/// Journalist fetching key pair
+/// Signed by the newsroom
+/// Medium-term X25519, same in 0.3
+#[derive(Clone)]
+pub struct JournalistFetchKeyPair {
+    pub public_key: DHPublicKey,
+    pub(crate) private_key: DHPrivateKey,
+}
+
+impl JournalistFetchKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistFetchKeyPair {
+        let (private_key, public_key) = crate::primitives::x25519::generate_dh_keypair(&mut rng)
+            .expect("DH key generation failed");
+        JournalistFetchKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
+/// Journalist medium term keypair
+/// Signed by the newsroom
+///
+/// Only used in 0.2
+#[deprecated]
+#[derive(Clone)]
+pub struct JournalistDHKeyPair {
+    pub public_key: DHPublicKey,
+    pub(crate) private_key: DHPrivateKey,
+}
+
+impl JournalistDHKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistDHKeyPair {
+        let (private_key, public_key) = crate::primitives::x25519::generate_dh_keypair(&mut rng)
+            .expect("DH key generation failed");
+        JournalistDHKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
+/// Journalist ephemeral KEM key pair
+/// Signed by the journalist signing key
+/// Only used in 0.2
+#[deprecated]
+pub struct JournalistEphemeralKEMKeyPair {
+    pub public_key: PPKPublicKey,
+    pub(crate) private_key: PPKPrivateKey,
+}
+
+impl JournalistEphemeralKEMKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistEphemeralKEMKeyPair {
+        // Temporarily use DH keys as PPK placeholders
+        let (dh_private_key, dh_public_key) =
+            crate::primitives::x25519::generate_dh_keypair(&mut rng)
+                .expect("DH key generation failed");
+        let private_key = PPKPrivateKey::new(dh_private_key);
+        let public_key = PPKPublicKey::new(dh_public_key);
+        JournalistEphemeralKEMKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
+/// Journalist ephemeral PKE key pair
+/// Signed by the journalist signing key
+/// Only used in 0.2
+#[deprecated]
+pub struct JournalistEphemeralPKEKeyPair {
+    pub(crate) public_key: PPKPublicKey,
+    private_key: PPKPrivateKey,
+}
+
+impl JournalistEphemeralPKEKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistEphemeralPKEKeyPair {
+        // Temporarily use DH keys as PPK placeholders
+        let (dh_private_key, dh_public_key) =
+            crate::primitives::x25519::generate_dh_keypair(&mut rng)
+                .expect("DH key generation failed");
+        let private_key = PPKPrivateKey::new(dh_private_key);
+        let public_key = PPKPublicKey::new(dh_public_key);
+        JournalistEphemeralPKEKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
+/// Journalist ephemeral DH-AKEM keypair
+/// Signed by the journalist signing key
+/// Only used in 0.2
+#[deprecated]
+pub struct JournalistEphemeralDHKeyPair {
+    pub(crate) public_key: DHPublicKey,
+    private_key: DHPrivateKey,
+}
+
+impl JournalistEphemeralDHKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> JournalistEphemeralDHKeyPair {
+        let (private_key, public_key) = crate::primitives::x25519::generate_dh_keypair(&mut rng)
+            .expect("DH key generation failed");
+        JournalistEphemeralDHKeyPair {
+            private_key,
+            public_key,
+        }
+    }
+}
+
+/// Journalist message encryption PSK (used for PQ secret)
+///
+/// One-time key
+///
+/// $J_epq$ in the specification.
+#[derive(Clone)]
+pub struct JournalistOneTimeMessagePQKeyPair {
+    pub public_key: MLKEM768PublicKey,
+    pub(crate) private_key: MLKEM768PrivateKey,
+}
+
+/// Journalist message encryption keypair
+///
+/// One-time key
+///
+/// $J_epke$ in the specification.
+#[derive(Clone)]
+pub struct JournalistOneTimeMessageClassicalKeyPair {
+    pub public_key: DhAkemPublicKey,
+    pub(crate) private_key: DhAkemPrivateKey,
+}
+
+/// Journalist metadata keypair
+///
+/// One-time key
+///
+/// $J_emd$ in the specification.
+#[derive(Clone)]
+pub struct JournalistOneTimeMetadataKeyPair {
+    pub public_key: XWingPublicKey,
+    pub(crate) private_key: XWingPrivateKey,
+}
+
+/// One-time public keys for a journalist (without signature)
+///
+/// This struct contains just the one-time public keys that need to be signed.
+/// Used for creating the message to sign in Step 3.2.
+///
+/// Updated for 0.3 spec with new key types:
+/// - J_{epq} (MLKEM-768) for message enc PSK (one-time)
+/// - J_{epke} (DH-AKEM) for message enc (one-time)
+/// - J_{emd} (XWING) for metadata enc (one-time)
+#[derive(Debug, Clone)]
+pub struct JournalistOneTimePublicKeys {
+    /// One-time MLKEM-768 public key for message enc PSK (one-time)
+    pub one_time_message_pq_pk: MLKEM768PublicKey,
+    /// One-time DH-AKEM public key for message enc (one-time)
+    pub one_time_message_pk: DhAkemPublicKey,
+    /// One-time XWING public key for metadata enc (one-time)
+    pub one_time_metadata_pk: XWingPublicKey,
+}
+
+impl JournalistOneTimePublicKeys {
+    /// Convert the one-time public keys to a byte array for signing
+    ///
+    /// Returns a byte array containing the concatenated public keys:
+    /// - one_time_message_pq_pk (1184 bytes) - MLKEM-768
+    /// - one_time_message_pk (32 bytes) - DH-AKEM
+    /// - one_time_metadata_pk (1216 bytes) - XWING
+    ///
+    /// Total: 2432 bytes
+    pub fn into_bytes(self) -> [u8; 2432] {
+        let mut bytes = [0u8; 2432];
+
+        // One-time MLKEM-768 public key (1184 bytes)
+        bytes[0..1184].copy_from_slice(self.one_time_message_pq_pk.as_bytes());
+
+        // One-time DH-AKEM public key (32 bytes)
+        bytes[1184..1216].copy_from_slice(self.one_time_message_pk.as_bytes());
+
+        // One-time XWING public key (1216 bytes)
+        bytes[1216..2432].copy_from_slice(self.one_time_metadata_pk.as_bytes());
+
+        bytes
+    }
+}
+
+/// One-time key set for a journalist
+#[derive(Debug, Clone)]
+pub struct JournalistOneTimeKeyBundle {
+    /// The one-time public keys
+    pub public_keys: JournalistOneTimePublicKeys,
+    /// Journalist's signature over the one-time keys
+    pub signature: Signature,
+}
+
+/// Journalist enrollment key bundle for 0.3 spec
+///
+/// This bundle is used to enroll a journalist into the system.
+#[derive(Clone)]
+pub struct JournalistEnrollmentKeyBundle {
+    /// Journalist's signing key
+    pub signing_key: VerifyingKey,
+    /// Journalist's fetching key
+    pub fetching_key: DHPublicKey,
+}
+
+impl JournalistEnrollmentKeyBundle {
+    /// Convert the enrollment key bundle to a byte array for signing
+    ///
+    /// Returns a byte array containing the concatenated public keys:
+    /// - signing_key (32 bytes)
+    /// - fetching_key (32 bytes)
+    /// Total: 64 bytes
+    pub fn into_bytes(self) -> [u8; 64] {
+        let mut bytes = [0u8; 64];
+
+        // Signing key verification key (32 bytes)
+        bytes[0..32].copy_from_slice(&self.signing_key.into_bytes());
+
+        // Fetching key public key (32 bytes)
+        bytes[32..64].copy_from_slice(&self.fetching_key.into_bytes());
+
+        bytes
+    }
+}

--- a/securedrop-protocol/src/keys/newsroom.rs
+++ b/securedrop-protocol/src/keys/newsroom.rs
@@ -1,0 +1,19 @@
+use rand::{CryptoRng, RngCore};
+
+use crate::sign::{SigningKey, VerifyingKey};
+
+/// Newsroom keypair used for signing.
+///
+/// TODO: Make the signing key private.
+pub struct NewsroomKeyPair {
+    pub vk: VerifyingKey,
+    pub sk: SigningKey,
+}
+
+impl NewsroomKeyPair {
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> NewsroomKeyPair {
+        let sk = SigningKey::new(&mut rng).unwrap();
+        let vk = sk.vk;
+        NewsroomKeyPair { sk, vk }
+    }
+}

--- a/securedrop-protocol/src/keys/source.rs
+++ b/securedrop-protocol/src/keys/source.rs
@@ -1,0 +1,252 @@
+use rand_core::{CryptoRng, RngCore};
+
+use crate::primitives::{
+    PPKPrivateKey, PPKPublicKey,
+    dh_akem::{DhAkemPrivateKey, DhAkemPublicKey},
+    mlkem::{MLKEM768PrivateKey, MLKEM768PublicKey},
+    x25519::{DHPrivateKey, DHPublicKey},
+    xwing::{XWingPrivateKey, XWingPublicKey},
+};
+
+/// Source public keys needed for journalist to reply to a source
+///
+/// This contains the ephemeral keys that the source provided during their message submission.
+#[derive(Debug, Clone)]
+pub struct SourcePublicKeys {
+    /// Source's ephemeral DH public key
+    pub ephemeral_dh_pk: DHPublicKey,
+    /// Source's ephemeral KEM public key
+    pub ephemeral_kem_pk: PPKPublicKey,
+    /// Source's ephemeral PKE public key
+    pub ephemeral_pke_pk: PPKPublicKey,
+    /// Source's fetching public key
+    pub fetch_pk: DHPublicKey,
+}
+
+// TODO: Name these better
+
+#[derive(Debug, Clone)]
+pub struct SourceKeyBundle {
+    pub fetch: SourceFetchKeyPair,
+    pub long_term_dh: SourceDHKeyPair,
+    pub kem: SourceKEMKeyPair,
+    pub pke: SourcePKEKeyPair,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourcePassphrase {
+    /// TODO make a string
+    pub passphrase: [u8; 32],
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceFetchKeyPair {
+    pub public_key: DHPublicKey,
+    pub(crate) private_key: DHPrivateKey,
+}
+
+impl SourceFetchKeyPair {
+    /// Create a fetch key pair from private key bytes
+    fn new(private_key_bytes: [u8; 32]) -> Self {
+        let private_key = DHPrivateKey::from_bytes(private_key_bytes);
+
+        let mut public_key_bytes = [0u8; 32];
+        libcrux_curve25519::secret_to_public(&mut public_key_bytes, &private_key_bytes);
+        let public_key = DHPublicKey::from_bytes(public_key_bytes);
+
+        Self {
+            public_key,
+            private_key,
+        }
+    }
+
+    /// Get the public key as bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public_key.clone().into_bytes()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[deprecated]
+pub struct SourceDHKeyPair {
+    pub public_key: DHPublicKey,
+    pub(crate) private_key: DHPrivateKey,
+}
+
+impl SourceDHKeyPair {
+    /// Create a DH key pair from private key bytes
+    fn new(private_key_bytes: [u8; 32]) -> Self {
+        let private_key = DHPrivateKey::from_bytes(private_key_bytes);
+
+        let mut public_key_bytes = [0u8; 32];
+        libcrux_curve25519::secret_to_public(&mut public_key_bytes, &private_key_bytes);
+        let public_key = DHPublicKey::from_bytes(public_key_bytes);
+
+        Self {
+            public_key,
+            private_key,
+        }
+    }
+
+    /// Get the public key as bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public_key.clone().into_bytes()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[deprecated]
+pub struct SourceKEMKeyPair {
+    pub public_key: PPKPublicKey,
+    pub(crate) private_key: PPKPrivateKey,
+}
+
+impl SourceKEMKeyPair {
+    /// Create a KEM key pair from private key bytes
+    fn new(private_key_bytes: [u8; 32]) -> Self {
+        let private_key = PPKPrivateKey::new(DHPrivateKey::from_bytes(private_key_bytes));
+
+        let mut public_key_bytes = [0u8; 32];
+        libcrux_curve25519::secret_to_public(&mut public_key_bytes, &private_key_bytes);
+        let public_key = PPKPublicKey::new(DHPublicKey::from_bytes(public_key_bytes));
+
+        Self {
+            public_key,
+            private_key,
+        }
+    }
+
+    /// Get the public key as bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public_key.clone().into_bytes()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[deprecated]
+pub struct SourcePKEKeyPair {
+    pub public_key: PPKPublicKey,
+    pub(crate) private_key: PPKPrivateKey,
+}
+
+impl SourcePKEKeyPair {
+    /// Create a PKE key pair from private key bytes
+    fn new(private_key_bytes: [u8; 32]) -> Self {
+        let private_key = PPKPrivateKey::new(DHPrivateKey::from_bytes(private_key_bytes));
+
+        let mut public_key_bytes = [0u8; 32];
+        libcrux_curve25519::secret_to_public(&mut public_key_bytes, &private_key_bytes);
+        let public_key = PPKPublicKey::new(DHPublicKey::from_bytes(public_key_bytes));
+
+        Self {
+            public_key,
+            private_key,
+        }
+    }
+
+    /// Get the public key as bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public_key.clone().into_bytes()
+    }
+}
+
+// new 0.3 keys
+
+/// Source message encryption PSK (used for PQ secret)
+///
+/// $S_pq$ in the specification.
+pub struct SourceMessagePQKeyPair {
+    pub public_key: MLKEM768PublicKey,
+    pub(crate) private_key: MLKEM768PrivateKey,
+}
+
+/// Source message encryption keypair
+///
+/// $S_pke$ in the specification.
+pub struct SourceMessageClassicalKeyPair {
+    pub public_key: DhAkemPublicKey,
+    pub(crate) private_key: DhAkemPrivateKey,
+}
+
+/// Source metadata keypair
+///
+/// $S_md$ in the specification.
+pub struct SourceMetadataKeyPair {
+    pub public_key: XWingPublicKey,
+    pub(crate) private_key: XWingPrivateKey,
+}
+
+/// Generate a passphrase and the corresponding keys (via KDF).
+impl SourceKeyBundle {
+    /// Get the source's DH public key
+    pub fn dh_public_key(&self) -> &DHPublicKey {
+        &self.long_term_dh.public_key
+    }
+
+    /// Get the source's PKE public key
+    pub fn pke_public_key(&self) -> &PPKPublicKey {
+        &self.pke.public_key
+    }
+
+    /// Get the source's KEM public key
+    pub fn kem_public_key(&self) -> &PPKPublicKey {
+        &self.kem.public_key
+    }
+
+    /// Get the source's fetch public key
+    pub fn fetch_public_key(&self) -> &DHPublicKey {
+        &self.fetch.public_key
+    }
+
+    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> (SourcePassphrase, SourceKeyBundle) {
+        // Generate a random passphrase
+        let mut passphrase = [0u8; 32];
+        rng.fill_bytes(&mut passphrase);
+
+        let source_passphrase = SourcePassphrase { passphrase };
+
+        // Derive all keys from the passphrase
+        let key_bundle = Self::from_passphrase(&passphrase);
+
+        (source_passphrase, key_bundle)
+    }
+
+    /// Reconstruct keys from an existing passphrase
+    ///
+    /// TODO: I deviated a bit from the spec
+    pub fn from_passphrase(passphrase: &[u8]) -> Self {
+        use blake2::{Blake2b, Digest};
+
+        // DH key
+        let mut dh_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        dh_hasher.update(b"SD_DH_KEY");
+        dh_hasher.update(passphrase);
+        let dh_result = dh_hasher.finalize();
+
+        // Fetch key
+        let mut fetch_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        fetch_hasher.update(b"SD_FETCH_KEY");
+        fetch_hasher.update(passphrase);
+        let fetch_result = fetch_hasher.finalize();
+
+        // PKE key
+        let mut pke_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        pke_hasher.update(b"SD_PKE_KEY");
+        pke_hasher.update(passphrase);
+        let pke_result = pke_hasher.finalize();
+
+        // KEM key
+        let mut kem_hasher = Blake2b::<blake2::digest::typenum::U32>::new();
+        kem_hasher.update(b"SD_KEM_KEY");
+        kem_hasher.update(passphrase);
+        let kem_result = kem_hasher.finalize();
+
+        // Create key pairs
+        Self {
+            fetch: SourceFetchKeyPair::new(fetch_result.into()),
+            long_term_dh: SourceDHKeyPair::new(dh_result.into()),
+            kem: SourceKEMKeyPair::new(kem_result.into()),
+            pke: SourcePKEKeyPair::new(pke_result.into()),
+        }
+    }
+}

--- a/securedrop-protocol/src/lib.rs
+++ b/securedrop-protocol/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+
+//! A draft implementation of the SecureDrop protocol.
+//!
+//! WARNING: This was implemented only for benchmarking and research purposes
+//! and is not ready for production use.
+
+extern crate alloc;
+
+/// The keys used in the SecureDrop protocol.
+pub mod keys;
+
+/// Common client functionality.
+pub mod client;
+pub use client::Client;
+
+/// Protocol messages used in the setup and core messaging protocol.
+pub mod messages;
+
+/// Server-side protocol implementation.
+pub mod server;
+
+/// Source-side protocol implementation.
+pub mod source;
+
+/// Journalist-side protocol implementation.
+pub mod journalist;
+
+/// Setup steps in the protocol.
+pub mod setup;
+
+/// Primitives for DH, PPK.
+pub mod primitives;
+
+/// Primitives for signing.
+///
+/// TODO: Move to primitives?
+pub mod sign;
+
+pub use sign::{Signature, SigningKey, VerifyingKey};
+
+/// Server storage
+pub mod storage;
+
+/// Benchmark loops that can be invoked from native or wasm callers.
+pub mod bench;

--- a/securedrop-protocol/src/messages.rs
+++ b/securedrop-protocol/src/messages.rs
@@ -1,0 +1,3 @@
+//! Protocol messages
+pub mod core;
+pub mod setup;

--- a/securedrop-protocol/src/messages/core.rs
+++ b/securedrop-protocol/src/messages/core.rs
@@ -1,0 +1,252 @@
+use crate::client::StructuredMessage;
+use crate::primitives::{
+    PPKPublicKey, dh_akem::DhAkemPublicKey, mlkem::MLKEM768PublicKey, x25519::DHPublicKey,
+    xwing::XWingPublicKey,
+};
+use crate::{Signature, VerifyingKey};
+use alloc::vec::Vec;
+use uuid::Uuid;
+
+pub struct MessageBundle {
+    /// C
+    pub sealed_envelope: SealedEnvelope,
+    /// (Z, X)
+    pub message_clue: MessageClue,
+}
+
+pub struct SealedEnvelope {
+    /// HPKE AuthPSK Sealed ciphertext
+    pub sealed_message: SealedMessage,
+
+    /// HPKE BaseMode Sealed X-WING encapsulated metadata (contains
+    /// sender pubkey needed to open SealedMessage.
+    /// See https://www.rfc-editor.org/rfc/rfc9180#section-9.9)
+    pub sealed_metadata: SealedMessageMetadata,
+    /// X-WING shared secret encaps, 1120 bytes
+    pub metadata_encaps: Vec<u16>,
+}
+
+/// Sealed metadata bytes
+pub struct SealedMessageMetadata {}
+
+/// Metadata for decrypting ciphertext
+/// TODO: check int sizes
+pub struct MessageMetadata {
+    pub sender_key: DHPublicKey,
+    message_dhakem_secret_encaps: Vec<u8>,
+    message_psk_secret_encaps: Vec<u8>,
+}
+
+/// Ciphertext bytes
+pub struct SealedMessage {}
+
+/// TODO: Plaintext message structure (i.e what keys or hashes of keys are included?)
+/// At minimum:
+/// Sender XWING key (for replies metadata)
+/// Sender MLKEM key (for replies)
+/// Identifiers: newsroom identifier
+/// Fetching key identifier?
+/// DH-AKEM key identifier (maybe not needed bc of how auth mode in hpke works)?
+/// Plaintext
+//pub struct Message {}
+
+/// (Z, X)
+pub struct MessageClue {
+    /// DH share
+    pub clue_bytes: Vec<u8>,
+    /// Ephemeral DH pubkey
+    pub clue_pubkey: DHPublicKey,
+}
+
+/// Source fetches keys for the newsroom
+///
+/// This is the first request in step 5 of the spec.
+pub struct SourceNewsroomKeyRequest {}
+
+/// Newsroom returns their keys and proof of onboarding.
+///
+/// This is the first response in step 5 of the spec.
+pub struct SourceNewsroomKeyResponse {
+    pub newsroom_verifying_key: VerifyingKey,
+    pub fpf_sig: Signature,
+}
+
+/// Source fetches journalist keys for the newsroom
+///
+/// This is part of step 5 in the spec.
+///
+/// Note: This isn't currently written down in the spec, but
+/// should occur right before the server provides a long-term
+/// key and an ephmeral key bundle for the journalist.
+pub struct SourceJournalistKeyRequest {}
+
+/// Server returns journalist long-term keys and ephemeral keys
+///
+/// This is the second part of step 5 in the spec.
+///
+/// Updated for 0.3 spec with new key types:
+/// - ephemeral_dh_pk: MLKEM-768 for message enc PSK (one-time)
+/// - ephemeral_kem_pk: DH-AKEM for message enc (one-time)
+/// - ephemeral_pke_pk: XWING for metadata enc (one-time)
+pub struct SourceJournalistKeyResponse {
+    /// Journalist's signing public key
+    pub journalist_sig_pk: VerifyingKey,
+    /// Journalist's fetching public key
+    pub journalist_fetch_pk: DHPublicKey,
+    /// Journalist's long-term DH public key
+    pub journalist_dh_pk: DHPublicKey,
+    /// Newsroom's signature over journalist keys
+    pub newsroom_sig: Signature,
+    /// MLKEM-768 public key for message enc PSK (one-time)
+    pub one_time_message_pq_pk: MLKEM768PublicKey,
+    /// DH-AKEM public key for message enc (one-time)
+    pub one_time_message_pk: DhAkemPublicKey,
+    /// XWING public key for metadata enc (one-time)
+    pub one_time_metadata_pk: XWingPublicKey,
+    /// Journalist's signature over ephemeral keys
+    pub journalist_ephemeral_sig: Signature,
+}
+
+/// Message structure for Step 6: Source submits a message
+///
+/// This represents the message format before padding and encryption:
+/// `msg || S_dh,pk || S_pke,pk || S_kem,pk || S_fetch,pk || J^i_sig,pk || NR`
+///
+/// Updated for 0.3 spec with new key types:
+/// - source_message_pq_pk: MLKEM-768 for message enc PSK (one-time)
+/// - source_message_pk: DH-AKEM for message enc (one-time)
+/// - source_metadata_pk: XWING for metadata enc (one-time)
+#[derive(Clone)]
+pub struct SourceMessage {
+    /// The actual message content
+    pub message: Vec<u8>,
+    /// Source's MLKEM-768 public key for message enc PSK (one-time)
+    pub source_message_pq_pk: MLKEM768PublicKey,
+    /// Source's DH-AKEM public key for message enc (one-time)
+    pub source_message_pk: DhAkemPublicKey,
+    /// Source's XWING public key for metadata enc (one-time)
+    pub source_metadata_pk: XWingPublicKey,
+    /// Source's fetching public key
+    pub source_fetch_pk: DHPublicKey,
+    /// Journalist's signing public key
+    pub journalist_sig_pk: VerifyingKey,
+    /// Newsroom signing public key
+    pub newsroom_sig_pk: VerifyingKey,
+}
+
+impl SourceMessage {
+    /// Serialize the message into bytes for padding and encryption
+    ///
+    /// Note: Deviated from spec here to put variable length field last
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(&self.source_message_pq_pk.as_bytes()[0..1184]);
+        bytes.extend_from_slice(&self.source_message_pk.as_bytes()[0..32]);
+        bytes.extend_from_slice(&self.source_metadata_pk.as_bytes()[0..1216]);
+        bytes.extend_from_slice(&self.source_fetch_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.journalist_sig_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.newsroom_sig_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.message);
+        bytes
+    }
+}
+
+impl StructuredMessage for SourceMessage {
+    fn into_bytes(self) -> Vec<u8> {
+        self.into_bytes()
+    }
+}
+
+/// Message structure for Step 9: Journalist replies to a source
+///
+/// This represents the message format before padding and encryption:
+/// `msg || S || J_sig,pk || J_fetch,pk || J_dh,pk || σ^NR || NR`
+#[derive(Clone)]
+pub struct JournalistReplyMessage {
+    /// The actual message content
+    pub message: Vec<u8>,
+    /// Source identifier (UUID)
+    pub source: Uuid,
+    /// Journalist's signing public key
+    pub journalist_sig_pk: VerifyingKey,
+    /// Journalist's fetching public key
+    pub journalist_fetch_pk: DHPublicKey,
+    /// Journalist's DH public key
+    pub journalist_dh_pk: DHPublicKey,
+    /// Newsroom signature
+    pub newsroom_signature: Signature,
+    /// Newsroom signing public key
+    pub newsroom_sig_pk: VerifyingKey,
+}
+
+impl JournalistReplyMessage {
+    /// Serialize the message into bytes for padding and encryption
+    ///
+    /// TODO: I deviated from the spec here to put the message last
+    /// because it's the only variable length field.
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&self.source.as_bytes()[0..16]);
+        bytes.extend_from_slice(&self.journalist_sig_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.journalist_fetch_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.journalist_dh_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.newsroom_signature.0[0..64]);
+        bytes.extend_from_slice(&self.newsroom_sig_pk.into_bytes()[0..32]);
+        bytes.extend_from_slice(&self.message);
+
+        bytes
+    }
+}
+
+impl StructuredMessage for JournalistReplyMessage {
+    fn into_bytes(self) -> Vec<u8> {
+        self.into_bytes()
+    }
+}
+
+/// User submits a message to the server $(C, Z, X)$
+///
+/// This corresponds to step 6 for sources and step 9 for journalists in the spec.
+/// TODO: could remove this, just kept it for consistency of naming with the other types
+pub type MessageSubmitRequest = MessageBundle;
+
+#[derive(Clone)]
+pub struct Message {
+    /// Encrypted message ciphertext
+    pub ciphertext: Vec<u8>,
+    /// Diffie-Hellman share Z
+    pub dh_share_z: Vec<u8>,
+    /// Diffie-Hellman share X
+    pub dh_share_x: Vec<u8>,
+}
+
+/// User (source or journalist) fetches message IDs
+///
+/// This corresponds to step 7 in the spec.
+pub struct MessageChallengeFetchRequest {}
+
+/// Server returns encrypted message IDs
+///
+/// This corresponds to step 7 in the spec.
+pub struct MessageChallengeFetchResponse {
+    /// Number of message entries returned
+    /// TODO: constant size array
+    pub count: usize,
+    /// Array of (Q, cid) pairs where Q is the group DH share and cid is encrypted message ID
+    /// TODO: constant size array
+    pub messages: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+/// User fetches a specific message by ID
+///
+/// This corresponds to step 8 and 10 in the spec.
+pub struct MessageFetchRequest {
+    /// Message ID to fetch
+    pub message_id: u64,
+}
+
+/// Server returns the requested message
+///
+/// This corresponds to step 8 and 10 in the spec.
+/// TODO: may remove alias
+pub type MessageFetchResponse = MessageBundle;

--- a/securedrop-protocol/src/messages/setup.rs
+++ b/securedrop-protocol/src/messages/setup.rs
@@ -1,0 +1,60 @@
+//! The setup steps included here are:
+//! * Newsroom onboarding (step 2 in the spec),
+//! * Journalist initial onboarding (step 3.1 in the spec),
+//! * Journalist ephemeral key replenishment (step 3.2 in the spec).
+//!
+//! The FPF setup process (step 1 in the spec) and source initial setup (step 4 in the spec)
+//! are both local only and do not involve any protocol messages.
+
+use crate::keys::{JournalistEnrollmentKeyBundle, JournalistOneTimeKeyBundle};
+use crate::{Signature, VerifyingKey};
+
+/// Request from the newsroom to FPF for verification.
+///
+/// Step 2 in the spec.
+pub struct NewsroomSetupRequest {
+    pub newsroom_verifying_key: VerifyingKey,
+}
+
+/// Response from FPF to the newsroom.
+///
+/// Step 2 in the spec.
+pub struct NewsroomSetupResponse {
+    /// A signature over the newsroom verifying key by the FPF signing key
+    pub sig: Signature,
+}
+
+/// Request from the journalist to the newsroom for initial onboarding.
+///
+/// Step 3.1 in the spec.
+pub struct JournalistSetupRequest {
+    pub enrollment_key_bundle: JournalistEnrollmentKeyBundle,
+}
+
+/// Response from the newsroom to the journalist for initial onboarding.
+///
+/// Step 3.1 in the spec.
+pub struct JournalistSetupResponse {
+    /// A signature over the journalist enrollment bundle by the newsroom signing key
+    pub sig: Signature,
+}
+
+/// Request from the journalist to the SecureDrop server for ephemeral key replenishment.
+///
+/// Step 3.2 in the spec.
+pub struct JournalistRefreshRequest {
+    /// Journalist's verifying key for identification
+    ///
+    /// NOTE: Not in spec, for discussion
+    pub journalist_verifying_key: VerifyingKey,
+    /// Bundle containing the journalist's ephemeral keys and signature
+    pub ephemeral_key_bundle: JournalistOneTimeKeyBundle,
+}
+
+/// Response from the server to the journalist for ephemeral key replenishment.
+///
+/// Step 3.2 in the spec.
+pub struct JournalistRefreshResponse {
+    /// Acknowledgment that the ephemeral keys were stored
+    pub success: bool,
+}

--- a/securedrop-protocol/src/primitives.rs
+++ b/securedrop-protocol/src/primitives.rs
@@ -1,0 +1,255 @@
+use alloc::vec::Vec;
+use anyhow::Error;
+use hpke_rs::{
+    Hpke,
+    hpke_types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
+    libcrux,
+    prelude::HpkeMode,
+};
+use libcrux_traits::kem::arrayref::Kem;
+use rand_core::{CryptoRng, RngCore};
+
+// Later: Can make these all pub(crate)
+pub mod dh_akem;
+pub mod mlkem;
+pub mod pad;
+pub mod x25519;
+pub mod xwing;
+
+pub use crate::primitives::dh_akem::generate_dh_akem_keypair;
+pub use crate::primitives::mlkem::generate_mlkem768_keypair;
+use crate::primitives::x25519::{DHPrivateKey, DHPublicKey};
+pub use crate::primitives::xwing::generate_xwing_keypair;
+
+/// Fixed number of message ID entries to return in privacy-preserving fetch
+///
+/// This prevents traffic analysis by always returning the same number of entries,
+/// regardless of how many actual messages exist.
+pub const MESSAGE_ID_FETCH_SIZE: usize = 10;
+
+/// Everything below here is 0.2 and will be updated / moved to the appropriate module
+
+// temp: use proper type
+#[derive(Debug, Clone)]
+pub struct PPKPrivateKey(DHPrivateKey);
+
+#[derive(Debug, Clone)]
+pub struct PPKPublicKey(DHPublicKey);
+
+impl PPKPublicKey {
+    pub fn new(public_key: DHPublicKey) -> Self {
+        Self(public_key)
+    }
+
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0.into_bytes()
+    }
+
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(DHPublicKey::from_bytes(bytes))
+    }
+}
+
+impl PPKPrivateKey {
+    pub fn new(private_key: DHPrivateKey) -> Self {
+        Self(private_key)
+    }
+
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0.into_bytes()
+    }
+
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(DHPrivateKey::from_bytes(bytes))
+    }
+}
+
+/// Authenticated encryption according to the SecureDrop protocol using HPKE
+///
+/// This implements HPKE AuthEnc mode as specified in the SecureDrop protocol
+/// using the source's DH private key and journalist's ephemeral keys
+///
+/// TODO: Horrible types in return value
+pub fn auth_encrypt(
+    source_dh_sk: &DHPrivateKey,
+    journalist_ephemeral_keys: (&DHPublicKey, &PPKPublicKey),
+    message: &[u8],
+) -> Result<((Vec<u8>, Vec<u8>), Vec<u8>), Error> {
+    // TODO: Update these based on primitive choices in final spec
+    // Note: We need to specify the crypto backend - using libcrux for consistency
+    let mut hpke: Hpke<libcrux::HpkeLibcrux> = Hpke::new(
+        HpkeMode::Auth,
+        KemAlgorithm::DhKem25519,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+    );
+
+    // Convert our key types to HPKE key types
+    // TODO: Need to use these HPKE types in the keys module
+    // For now, using placeholder keys
+    let sender_private_key =
+        hpke_rs::HpkePrivateKey::new(source_dh_sk.clone().into_bytes().to_vec());
+
+    // Need to also incorporate J_{ekem} here, mumble mumble something about PQ KEM
+    let recipient_public_key =
+        hpke_rs::HpkePublicKey::new(journalist_ephemeral_keys.0.clone().into_bytes().to_vec());
+
+    // Use HPKE seal for authenticated encryption
+    let (encapsulated_key, ciphertext) = hpke
+        .seal(
+            &recipient_public_key,     // pk_r: recipient's public key
+            &[],                       // info: empty for now
+            &[],                       // aad: empty for now (ε in the spec)
+            message,                   // plain_txt: the message to encrypt
+            None,                      // psk: no pre-shared key
+            None,                      // psk_id: no PSK ID
+            Some(&sender_private_key), // sk_s: sender's private key for authentication
+        )
+        .map_err(|e| anyhow::anyhow!("HPKE seal failed: {:?}", e))?;
+
+    // Split the encapsulated key into c1 and c2 components
+    // TODO: This is a placeholder
+    let c1 = if encapsulated_key.len() >= 32 {
+        encapsulated_key[..32].to_vec()
+    } else {
+        encapsulated_key.clone()
+    };
+
+    let c2 = if encapsulated_key.len() > 32 {
+        encapsulated_key[32..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    Ok(((c1, c2), ciphertext))
+}
+
+/// This implements HPKE Base mode (unauthenticated) for metadata encryption
+///
+/// TODO: Check this is correct
+pub fn enc(
+    journalist_epke_pk: &PPKPublicKey,
+    source_dh_pk: &DHPublicKey,
+    c1: &[u8],
+    c2: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Create HPKE configuration for Base mode (unauthenticated)
+    let mut hpke: Hpke<libcrux::HpkeLibcrux> = Hpke::new(
+        HpkeMode::Base, // Base mode for unauthenticated encryption
+        KemAlgorithm::DhKem25519,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+    );
+
+    // Convert recipient public key to HPKE format
+    let recipient_public_key =
+        hpke_rs::HpkePublicKey::new(journalist_epke_pk.clone().into_bytes().to_vec());
+
+    // Prepare metadata: S_dh,pk || c_1 || c_2
+    let mut metadata = Vec::new();
+    metadata.extend_from_slice(&source_dh_pk.clone().into_bytes());
+    metadata.extend_from_slice(c1);
+    metadata.extend_from_slice(c2);
+
+    // Setup sender (key encapsulation) in Base mode
+    let (encapsulated_key, mut context) = hpke
+        .setup_sender(
+            &recipient_public_key, // J^i_epke,pk
+            &[],                   // info: empty
+            None,                  // psk: no pre-shared key
+            None,                  // psk_id: no PSK ID
+            None,                  // sk_s: no sender private key (Base mode)
+        )
+        .map_err(|e| anyhow::anyhow!("HPKE setup_sender failed: {:?}", e))?;
+
+    // Encrypt the metadata using the derived context
+    let encrypted_metadata = context
+        .seal(
+            &[],       // aad: empty
+            &metadata, // S_dh,pk || c_1 || c_2
+        )
+        .map_err(|e| anyhow::anyhow!("HPKE context.seal failed: {:?}", e))?;
+
+    // Return encapsulated_key || encrypted_metadata
+    let mut result = Vec::new();
+    result.extend_from_slice(&encapsulated_key);
+    result.extend_from_slice(&encrypted_metadata);
+
+    Ok(result)
+}
+
+/// Symmetric encryption for message IDs using ChaCha20-Poly1305
+///
+/// This is used in step 7 for encrypting message IDs with a shared secret
+pub fn encrypt_message_id(key: &[u8], message_id: &[u8]) -> Result<Vec<u8>, Error> {
+    use libcrux_chacha20poly1305::{KEY_LEN, NONCE_LEN, TAG_LEN};
+
+    if key.len() != KEY_LEN {
+        return Err(anyhow::anyhow!("Invalid key length"));
+    }
+
+    // Generate a random nonce
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::rng().fill_bytes(&mut nonce);
+
+    // Prepare output buffer: nonce + ciphertext + tag
+    let mut output = alloc::vec::Vec::new();
+    output.extend_from_slice(&nonce);
+
+    let mut ciphertext = alloc::vec![0u8; message_id.len() + TAG_LEN];
+    let key_array: [u8; KEY_LEN] = key
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Key length mismatch"))?;
+
+    // Encrypt the message ID
+    libcrux_chacha20poly1305::encrypt(
+        &key_array,
+        message_id,
+        &mut ciphertext,
+        &[], // empty AAD
+        &nonce,
+    )
+    .map_err(|e| anyhow::anyhow!("ChaCha20-Poly1305 encryption failed: {:?}", e))?;
+
+    output.extend_from_slice(&ciphertext);
+    Ok(output)
+}
+
+/// Symmetric decryption for message IDs using ChaCha20-Poly1305
+///
+/// This is used in step 7 for decrypting message IDs with a shared secret
+pub fn decrypt_message_id(key: &[u8], encrypted_data: &[u8]) -> Result<Vec<u8>, Error> {
+    use libcrux_chacha20poly1305::{KEY_LEN, NONCE_LEN, TAG_LEN};
+
+    if key.len() != KEY_LEN {
+        return Err(anyhow::anyhow!("Invalid key length"));
+    }
+
+    if encrypted_data.len() < NONCE_LEN + TAG_LEN {
+        return Err(anyhow::anyhow!("Encrypted data too short"));
+    }
+
+    // Extract nonce and ciphertext
+    let nonce: [u8; NONCE_LEN] = encrypted_data[..NONCE_LEN]
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Nonce extraction failed"))?;
+    let ciphertext = &encrypted_data[NONCE_LEN..];
+
+    // Prepare output buffer
+    let mut plaintext = alloc::vec![0u8; ciphertext.len() - TAG_LEN];
+    let key_array: [u8; KEY_LEN] = key
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Key length mismatch"))?;
+
+    // Decrypt the message ID
+    libcrux_chacha20poly1305::decrypt(
+        &key_array,
+        &mut plaintext,
+        ciphertext,
+        &[], // empty AAD
+        &nonce,
+    )
+    .map_err(|e| anyhow::anyhow!("ChaCha20-Poly1305 decryption failed: {:?}", e))?;
+
+    Ok(plaintext)
+}

--- a/securedrop-protocol/src/primitives/dh_akem.rs
+++ b/securedrop-protocol/src/primitives/dh_akem.rs
@@ -1,0 +1,132 @@
+use rand_core::{CryptoRng, RngCore};
+
+pub const DH_AKEM_PUBLIC_KEY_LEN: usize = 32;
+pub const DH_AKEM_PRIVATE_KEY_LEN: usize = 32;
+pub const DH_AKEM_SECRET_LEN: usize = 32;
+
+/// An DH-AKEM public key.
+#[derive(Debug, Clone)]
+pub struct DhAkemPublicKey([u8; DH_AKEM_PUBLIC_KEY_LEN]);
+
+/// An DH-AKEM private key.
+#[derive(Debug, Clone)]
+pub struct DhAkemPrivateKey([u8; DH_AKEM_PRIVATE_KEY_LEN]);
+
+/// An DH-AKEM shared secret.
+#[derive(Debug, Clone)]
+pub struct DhAkemSecret([u8; DH_AKEM_SECRET_LEN]);
+
+impl DhAkemPublicKey {
+    /// Get the public key as bytes
+    pub fn as_bytes(&self) -> &[u8; DH_AKEM_PUBLIC_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; DH_AKEM_PUBLIC_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl DhAkemPrivateKey {
+    /// Get the private key as bytes
+    pub fn as_bytes(&self) -> &[u8; DH_AKEM_PRIVATE_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; DH_AKEM_PRIVATE_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl DhAkemSecret {
+    /// Get the shared secret as bytes
+    pub fn as_bytes(&self) -> &[u8; DH_AKEM_SECRET_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; DH_AKEM_SECRET_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Generate a new DH-AKEM key pair using libcrux_kem
+pub fn generate_dh_akem_keypair<R: RngCore + CryptoRng>(
+    rng: &mut R,
+) -> Result<(DhAkemPrivateKey, DhAkemPublicKey), anyhow::Error> {
+    use libcrux_kem::{Algorithm, key_gen};
+
+    // Generate DH-AKEM keypair using libcrux_kem with X25519
+    let (sk, pk) = key_gen(Algorithm::X25519, rng)
+        .map_err(|e| anyhow::anyhow!("DH-AKEM key generation failed: {:?}", e))?;
+
+    // Convert to our types
+    let private_key_bytes = sk.encode();
+    let public_key_bytes = pk.encode();
+
+    // Validate key sizes (X25519 should have consistent 32-byte sizes)
+    if private_key_bytes.len() != DH_AKEM_PRIVATE_KEY_LEN
+        || public_key_bytes.len() != DH_AKEM_PUBLIC_KEY_LEN
+    {
+        return Err(anyhow::anyhow!(
+            "Unexpected DH-AKEM key sizes: private={}, public={}",
+            private_key_bytes.len(),
+            public_key_bytes.len()
+        ));
+    }
+
+    let private_key = DhAkemPrivateKey::from_bytes(
+        private_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
+    );
+    let public_key = DhAkemPublicKey::from_bytes(
+        public_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
+    );
+
+    Ok((private_key, public_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    #[test]
+    fn test_dh_akem_key_generation() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_dh_akem_keypair(&mut rng).expect("Should generate DH-AKEM keypair");
+
+        // Verify key sizes
+        assert_eq!(private_key.as_bytes().len(), DH_AKEM_PRIVATE_KEY_LEN);
+        assert_eq!(public_key.as_bytes().len(), DH_AKEM_PUBLIC_KEY_LEN);
+
+        // Verify keys are different
+        assert_ne!(private_key.as_bytes(), public_key.as_bytes());
+    }
+
+    #[test]
+    fn test_dh_akem_key_serialization() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_dh_akem_keypair(&mut rng).expect("Should generate DH-AKEM keypair");
+
+        // Test round-trip serialization
+        let private_bytes = *private_key.as_bytes();
+        let public_bytes = *public_key.as_bytes();
+
+        let reconstructed_private = DhAkemPrivateKey::from_bytes(private_bytes);
+        let reconstructed_public = DhAkemPublicKey::from_bytes(public_bytes);
+
+        assert_eq!(private_key.as_bytes(), reconstructed_private.as_bytes());
+        assert_eq!(public_key.as_bytes(), reconstructed_public.as_bytes());
+    }
+}

--- a/securedrop-protocol/src/primitives/mlkem.rs
+++ b/securedrop-protocol/src/primitives/mlkem.rs
@@ -1,0 +1,119 @@
+use rand_core::{CryptoRng, RngCore};
+
+// From NIST ML-KEM spec:
+// https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf
+// See Table 2 which shows k = 3 for ML-KEM-768 and
+// Algorithm 19 which defines the size of the encap and decap keys in terms of k
+pub const MLKEM768_PUBLIC_KEY_LEN: usize = 1184;
+pub const MLKEM768_PRIVATE_KEY_LEN: usize = 2400;
+
+/// MLKEM-768 public key.
+#[derive(Debug, Clone)]
+pub struct MLKEM768PublicKey([u8; MLKEM768_PUBLIC_KEY_LEN]);
+
+/// MLKEM-768 private key.
+#[derive(Clone)]
+pub struct MLKEM768PrivateKey([u8; MLKEM768_PRIVATE_KEY_LEN]);
+
+impl MLKEM768PublicKey {
+    /// Get the public key as bytes
+    pub fn as_bytes(&self) -> &[u8; MLKEM768_PUBLIC_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; MLKEM768_PUBLIC_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl MLKEM768PrivateKey {
+    /// Get the private key as bytes
+    pub fn as_bytes(&self) -> &[u8; MLKEM768_PRIVATE_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; MLKEM768_PRIVATE_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Generate a new MLKEM-768 keypair using libcrux_kem
+pub fn generate_mlkem768_keypair<R: RngCore + CryptoRng>(
+    rng: &mut R,
+) -> Result<(MLKEM768PrivateKey, MLKEM768PublicKey), anyhow::Error> {
+    use libcrux_kem::{Algorithm, key_gen};
+
+    // Generate MLKEM-768 keypair using libcrux_kem
+    let (sk, pk) = key_gen(Algorithm::MlKem768, rng)
+        .map_err(|e| anyhow::anyhow!("MLKEM-768 key generation failed: {:?}", e))?;
+
+    // Convert to our types
+    let private_key_bytes = sk.encode();
+    let public_key_bytes = pk.encode();
+
+    // Validate key sizes (MLKEM-768 should have consistent sizes)
+    if private_key_bytes.len() != MLKEM768_PRIVATE_KEY_LEN
+        || public_key_bytes.len() != MLKEM768_PUBLIC_KEY_LEN
+    {
+        return Err(anyhow::anyhow!(
+            "Unexpected MLKEM-768 key sizes: private={}, public={}",
+            private_key_bytes.len(),
+            public_key_bytes.len()
+        ));
+    }
+
+    let private_key = MLKEM768PrivateKey::from_bytes(
+        private_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
+    );
+    let public_key = MLKEM768PublicKey::from_bytes(
+        public_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
+    );
+
+    Ok((private_key, public_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    #[test]
+    fn test_mlkem768_key_generation() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_mlkem768_keypair(&mut rng).expect("Should generate MLKEM-768 keypair");
+
+        // Verify key sizes
+        assert_eq!(private_key.as_bytes().len(), MLKEM768_PRIVATE_KEY_LEN);
+        assert_eq!(public_key.as_bytes().len(), MLKEM768_PUBLIC_KEY_LEN);
+
+        // Verify keys are different (they have different sizes anyway)
+        assert_ne!(private_key.as_bytes().len(), public_key.as_bytes().len());
+    }
+
+    #[test]
+    fn test_mlkem768_key_serialization() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_mlkem768_keypair(&mut rng).expect("Should generate MLKEM-768 keypair");
+
+        // Test round-trip serialization
+        let private_bytes = *private_key.as_bytes();
+        let public_bytes = *public_key.as_bytes();
+
+        let reconstructed_private = MLKEM768PrivateKey::from_bytes(private_bytes);
+        let reconstructed_public = MLKEM768PublicKey::from_bytes(public_bytes);
+
+        assert_eq!(private_key.as_bytes(), reconstructed_private.as_bytes());
+        assert_eq!(public_key.as_bytes(), reconstructed_public.as_bytes());
+    }
+}

--- a/securedrop-protocol/src/primitives/pad.rs
+++ b/securedrop-protocol/src/primitives/pad.rs
@@ -1,0 +1,25 @@
+use alloc::vec::Vec;
+
+/// Fixed-length padded message length.
+///
+/// Note: I made this up. We should pick something based on actual reasons.
+pub const PADDED_MESSAGE_LEN: usize = 1024;
+
+/// Pad a message to a fixed length
+pub fn pad_message(message: &[u8]) -> Vec<u8> {
+    if message.len() > PADDED_MESSAGE_LEN {
+        // TODO: Handle message truncation or error outside of this function
+        panic!("Message too long for padding");
+    }
+
+    let mut padded = Vec::with_capacity(PADDED_MESSAGE_LEN);
+    padded.extend_from_slice(message);
+
+    // Pad with zeros to reach the fixed length
+    let padding_needed = PADDED_MESSAGE_LEN - message.len();
+    for _ in 0..padding_needed {
+        padded.push(0u8);
+    }
+
+    padded
+}

--- a/securedrop-protocol/src/primitives/x25519.rs
+++ b/securedrop-protocol/src/primitives/x25519.rs
@@ -1,0 +1,102 @@
+use anyhow::Error;
+use libcrux_traits::kem::arrayref::Kem;
+use rand_core::{CryptoRng, RngCore};
+
+pub use libcrux_curve25519::{DK_LEN as SK_LEN, EK_LEN as PK_LEN};
+
+/// An X25519 public key.
+#[derive(Debug, Clone)]
+pub struct DHPublicKey([u8; PK_LEN]);
+
+impl DHPublicKey {
+    pub fn into_bytes(self) -> [u8; PK_LEN] {
+        self.0
+    }
+
+    pub fn from_bytes(bytes: [u8; PK_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// An X25519 private key.
+#[derive(Debug, Clone)]
+pub struct DHPrivateKey([u8; SK_LEN]);
+
+impl DHPrivateKey {
+    pub fn into_bytes(self) -> [u8; SK_LEN] {
+        self.0
+    }
+
+    pub fn from_bytes(bytes: [u8; SK_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// An X25519 shared secret.
+#[derive(Debug, Clone)]
+pub struct DHSharedSecret([u8; 32]);
+
+impl DHSharedSecret {
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Generate a new DH key pair using X25519
+pub fn generate_dh_keypair<R: RngCore + CryptoRng>(
+    mut rng: R,
+) -> Result<(DHPrivateKey, DHPublicKey), Error> {
+    let mut randomness = [0u8; 32];
+    rng.fill_bytes(&mut randomness);
+
+    let mut public_key = [0u8; PK_LEN];
+    let mut secret_key = [0u8; SK_LEN];
+
+    // Generate the key pair using X25519 from libcrux
+    // Parameters: ek (public key), dk (secret key), rand (randomness)
+    libcrux_curve25519::X25519::keygen(&mut public_key, &mut secret_key, &randomness)
+        .map_err(|_| anyhow::anyhow!("X25519 key generation failed"))?;
+
+    Ok((DHPrivateKey(secret_key), DHPublicKey(public_key)))
+}
+
+/// Generate a random scalar for DH operations using X25519
+pub fn generate_random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Result<[u8; 32], Error> {
+    let mut randomness = [0u8; 32];
+    rng.fill_bytes(&mut randomness);
+
+    let mut secret_key = [0u8; 32];
+    let mut _public_key = [0u8; 32]; // We don't need the public key here
+
+    // Generate the key pair using X25519 from libcrux
+    // Parameters: ek (public key), dk (secret key), rand (randomness)
+    libcrux_curve25519::X25519::keygen(&mut _public_key, &mut secret_key, &randomness)
+        .map_err(|_| anyhow::anyhow!("X25519 key generation failed"))?;
+
+    Ok(secret_key)
+}
+
+/// Convert a scalar to a DH public key using the X25519 standard generator base point
+///
+/// libcrux_curve25519::secret_to_public uses the standard X25519 base point G = 9
+/// (defined as [9, 0, 0, 0, ...] in the HACL implementation, see `g25519` in their code)
+pub fn dh_public_key_from_scalar(scalar: [u8; 32]) -> DHPublicKey {
+    let mut public_key_bytes = [0u8; 32];
+    libcrux_curve25519::secret_to_public(&mut public_key_bytes, &scalar);
+    DHPublicKey::from_bytes(public_key_bytes)
+}
+
+/// Compute DH shared secret
+pub fn dh_shared_secret(
+    public_key: &DHPublicKey,
+    private_scalar: [u8; 32],
+) -> Result<DHSharedSecret, Error> {
+    let mut shared_secret_bytes = [0u8; 32];
+    libcrux_curve25519::ecdh(&mut shared_secret_bytes, &private_scalar, &public_key.0)
+        .map_err(|_| anyhow::anyhow!("X25519 DH failed"))?;
+    Ok(DHSharedSecret(shared_secret_bytes))
+}

--- a/securedrop-protocol/src/primitives/xwing.rs
+++ b/securedrop-protocol/src/primitives/xwing.rs
@@ -1,0 +1,109 @@
+use rand_core::{CryptoRng, RngCore};
+
+// From: https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/
+pub const XWING_PUBLIC_KEY_LEN: usize = 1216;
+pub const XWING_PRIVATE_KEY_LEN: usize = 32;
+
+/// XWING public key.
+#[derive(Debug, Clone)]
+pub struct XWingPublicKey([u8; XWING_PUBLIC_KEY_LEN]);
+
+/// XWING private key.
+#[derive(Clone)]
+pub struct XWingPrivateKey([u8; XWING_PRIVATE_KEY_LEN]);
+
+impl XWingPublicKey {
+    /// Get the public key as bytes
+    pub fn as_bytes(&self) -> &[u8; XWING_PUBLIC_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; XWING_PUBLIC_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl XWingPrivateKey {
+    /// Get the private key as bytes
+    pub fn as_bytes(&self) -> &[u8; XWING_PRIVATE_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create from bytes
+    pub fn from_bytes(bytes: [u8; XWING_PRIVATE_KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Generate a new XWING keypair using libcrux_kem
+pub fn generate_xwing_keypair<R: RngCore + CryptoRng>(
+    rng: &mut R,
+) -> Result<(XWingPrivateKey, XWingPublicKey), anyhow::Error> {
+    use libcrux_kem::{Algorithm, key_gen};
+
+    // Generate XWING keypair using libcrux_kem
+    let (sk, pk) = key_gen(Algorithm::XWingKemDraft06, rng)
+        .map_err(|e| anyhow::anyhow!("XWING key generation failed: {:?}", e))?;
+
+    // Convert to our types
+    let private_key_bytes = sk.encode();
+    let public_key_bytes = pk.encode();
+
+    // Validate key sizes (XWING should have consistent sizes)
+    if private_key_bytes.len() != XWING_PRIVATE_KEY_LEN
+        || public_key_bytes.len() != XWING_PUBLIC_KEY_LEN
+    {
+        return Err(anyhow::anyhow!(
+            "Unexpected XWING key sizes: private={}, public={}",
+            private_key_bytes.len(),
+            public_key_bytes.len()
+        ));
+    }
+
+    let private_key = XWingPrivateKey::from_bytes(
+        private_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert private key bytes"))?,
+    );
+    let public_key = XWingPublicKey::from_bytes(
+        public_key_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Failed to convert public key bytes"))?,
+    );
+
+    Ok((private_key, public_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    #[test]
+    fn test_xwing_key_generation() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_xwing_keypair(&mut rng).expect("Should generate XWING keypair");
+    }
+
+    #[test]
+    fn test_xwing_key_serialization() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let (private_key, public_key) =
+            generate_xwing_keypair(&mut rng).expect("Should generate XWING keypair");
+
+        // Test round-trip serialization
+        let private_bytes = *private_key.as_bytes();
+        let public_bytes = *public_key.as_bytes();
+
+        let reconstructed_private = XWingPrivateKey::from_bytes(private_bytes);
+        let reconstructed_public = XWingPublicKey::from_bytes(public_bytes);
+
+        assert_eq!(private_key.as_bytes(), reconstructed_private.as_bytes());
+        assert_eq!(public_key.as_bytes(), reconstructed_public.as_bytes());
+    }
+}

--- a/securedrop-protocol/src/server.rs
+++ b/securedrop-protocol/src/server.rs
@@ -1,0 +1,336 @@
+//! Server-side protocol implementation
+//!
+//! This module implements the server-side handling of SecureDrop protocol steps 5-10.
+
+use alloc::vec::Vec;
+use anyhow::{Error, anyhow};
+use rand::seq::SliceRandom;
+use rand_core::{CryptoRng, RngCore};
+use uuid::Uuid;
+
+use crate::keys::NewsroomKeyPair;
+use crate::messages::core::{
+    Message, MessageChallengeFetchRequest, MessageChallengeFetchResponse, MessageFetchRequest,
+    MessageFetchResponse, SourceJournalistKeyRequest, SourceJournalistKeyResponse,
+    SourceNewsroomKeyRequest, SourceNewsroomKeyResponse,
+};
+use crate::messages::setup::{
+    JournalistRefreshRequest, JournalistRefreshResponse, JournalistSetupRequest,
+    JournalistSetupResponse, NewsroomSetupRequest,
+};
+use crate::primitives::{
+    MESSAGE_ID_FETCH_SIZE, encrypt_message_id,
+    x25519::{dh_public_key_from_scalar, dh_shared_secret, generate_random_scalar},
+};
+use crate::sign::{Signature, VerifyingKey};
+use crate::storage::ServerStorage;
+
+/// Server session for handling source requests
+#[derive(Default)]
+pub struct Server {
+    storage: ServerStorage,
+    newsroom_keys: Option<NewsroomKeyPair>,
+    /// Signature from FPF over the newsroom keys
+    signature: Option<Signature>,
+}
+
+impl Server {
+    /// Create a new server session
+    ///
+    /// TODO: Load newsroom keys from storage if they exist.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Generate a new newsroom setup request.
+    ///
+    /// This creates a newsroom key pair, stores it in the server storage,
+    /// and returns a setup request that can be sent to FPF for signing.
+    ///
+    /// TODO: The caller should persist these keys to disk.
+    pub fn create_newsroom_setup_request<R: RngCore + CryptoRng>(
+        &mut self,
+        mut rng: R,
+    ) -> Result<NewsroomSetupRequest, Error> {
+        let newsroom_keys = NewsroomKeyPair::new(&mut rng);
+        let newsroom_vk = newsroom_keys.vk;
+
+        // Store the newsroom keys in the session for later use (e.g., signing journalist keys)
+        self.newsroom_keys = Some(newsroom_keys);
+
+        Ok(NewsroomSetupRequest {
+            newsroom_verifying_key: newsroom_vk,
+        })
+    }
+
+    /// Setup a journalist. This corresponds to step 3.1 in the spec.
+    ///
+    /// The newsroom then signs the bundle of journalist public keys.
+    ///
+    /// TODO: There is a manual verification step here, so the caller should
+    /// instruct the user to stop, verify the fingerprint out of band, and
+    /// then proceed. The caller should also persist the fingerprint and signature
+    /// in its local data store.
+    ///
+    /// TODO(later): How to handle signing when offline? (Not relevant for benchmarking)
+    pub fn setup_journalist(
+        &mut self,
+        request: JournalistSetupRequest,
+    ) -> Result<JournalistSetupResponse, Error> {
+        // Get enrollment key bundle bytes from the request
+        let enrollment_key_bundle_bytes = request.enrollment_key_bundle.clone().into_bytes();
+
+        // Sign the journalist bundle
+        let newsroom_keys = self
+            .newsroom_keys
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Newsroom keys not found in session"))?;
+        let newsroom_signature = newsroom_keys.sk.sign(&enrollment_key_bundle_bytes);
+
+        // Insert journalist keys into storage
+        let _journalist_id = self
+            .storage
+            .add_journalist(request.enrollment_key_bundle, newsroom_signature.clone());
+
+        Ok(JournalistSetupResponse {
+            sig: newsroom_signature,
+        })
+    }
+
+    /// Handle journalist ephemeral key replenishment. This corresponds to step 3.2 in the spec.
+    ///
+    /// The journalist sends ephemeral keys signed by their signing key, and the server
+    /// verifies the signature and stores the ephemeral keys.
+    pub fn handle_ephemeral_key_request(
+        &mut self,
+        request: JournalistRefreshRequest,
+    ) -> Result<JournalistRefreshResponse, Error> {
+        let bundle = request.ephemeral_key_bundle;
+
+        // Get the ephemeral public keys from the bundle
+        let ephemeral_public_keys = &bundle.public_keys;
+
+        // Create the message that was signed
+        let signed_message = ephemeral_public_keys.clone().into_bytes();
+
+        // Look up the journalist by their verifying key
+        let journalist_id = self
+            .storage
+            .find_journalist_by_verifying_key(&request.journalist_verifying_key)
+            .ok_or_else(|| anyhow::anyhow!("Journalist not found in storage"))?;
+
+        // Verify the signature using the journalist's verifying key
+        request
+            .journalist_verifying_key
+            .verify(&signed_message, &bundle.signature)
+            .map_err(|_| anyhow::anyhow!("Invalid signature on ephemeral keys"))?;
+
+        // Store the ephemeral keys for the journalist
+        self.storage
+            .add_ephemeral_keys(journalist_id, Vec::from([bundle]));
+
+        Ok(JournalistRefreshResponse { success: true })
+    }
+
+    /// Get the newsroom verifying key
+    pub fn get_newsroom_verifying_key(&self) -> Option<&VerifyingKey> {
+        self.newsroom_keys.as_ref().map(|keys| &keys.vk)
+    }
+
+    /// Set the FPF signature for the newsroom
+    pub fn set_fpf_signature(&mut self, signature: Signature) {
+        self.signature = Some(signature);
+    }
+
+    /// Get the ephemeral key count for a journalist
+    pub fn ephemeral_keys_count(&self, journalist_id: Uuid) -> usize {
+        self.storage.ephemeral_keys_count(journalist_id)
+    }
+
+    /// Check if a journalist has ephemeral keys available
+    pub fn has_ephemeral_keys(&self, journalist_id: Uuid) -> bool {
+        self.storage.has_ephemeral_keys(journalist_id)
+    }
+
+    /// Find journalist ID by verifying key
+    pub fn find_journalist_id(&self, verifying_key: &VerifyingKey) -> Option<Uuid> {
+        self.storage.find_journalist_by_verifying_key(verifying_key)
+    }
+
+    /// Check if a message exists with the given ID
+    pub fn has_message(&self, message_id: &Uuid) -> bool {
+        self.storage.get_messages().contains_key(message_id)
+    }
+
+    /// Handle source newsroom key request (step 5)
+    pub fn handle_source_newsroom_key_request(
+        &self,
+        _request: SourceNewsroomKeyRequest,
+    ) -> SourceNewsroomKeyResponse {
+        SourceNewsroomKeyResponse {
+            newsroom_verifying_key: self
+                .newsroom_keys
+                .as_ref()
+                .expect("Newsroom keys not found")
+                .vk,
+            fpf_sig: self
+                .signature
+                .as_ref()
+                .expect("FPF signature not found")
+                .clone(),
+        }
+    }
+
+    /// Handle source journalist key request (step 5)
+    pub fn handle_source_journalist_key_request<R: RngCore + CryptoRng>(
+        &mut self,
+        _request: SourceJournalistKeyRequest,
+        rng: &mut R,
+    ) -> Vec<SourceJournalistKeyResponse> {
+        let mut responses = Vec::new();
+
+        // Get all journalists and their ephemeral keys
+        let journalist_ephemeral_keys = self.storage.get_all_ephemeral_keys(rng);
+
+        for (journalist_id, ephemeral_bundle) in journalist_ephemeral_keys {
+            // Get the journalist's long-term keys
+            // TODO: Do something better than expect here
+            let (signing_key, fetching_key, newsroom_sig) = self
+                .storage
+                .get_journalists()
+                .get(&journalist_id)
+                .expect("Journalist should exist in storage")
+                .clone();
+
+            // Create response for this journalist
+            // temp: duplicated the fetching key so things compile while we transition to 0.3 spec
+            let response = SourceJournalistKeyResponse {
+                journalist_sig_pk: signing_key,
+                journalist_fetch_pk: fetching_key.clone(),
+                journalist_dh_pk: fetching_key,
+                newsroom_sig,
+                one_time_message_pq_pk: ephemeral_bundle.public_keys.one_time_message_pq_pk,
+                one_time_message_pk: ephemeral_bundle.public_keys.one_time_message_pk,
+                one_time_metadata_pk: ephemeral_bundle.public_keys.one_time_metadata_pk,
+                journalist_ephemeral_sig: ephemeral_bundle.signature,
+            };
+
+            responses.push(response);
+        }
+
+        responses
+    }
+
+    /// Handle message submission (step 6 for sources, step 9 for journalists)
+    pub fn handle_message_submit(&mut self, message: Message) -> Result<Uuid, Error> {
+        // Generate a random message ID
+        let message_id = Uuid::new_v4();
+
+        // Store the message with the generated ID
+        self.storage.add_message(message_id, message);
+
+        Ok(message_id)
+    }
+
+    /// Handle message ID fetch request (step 7)
+    ///
+    /// TODO: Nothing here prevents someone from requesting messages
+    /// that aren't theirs? Should request messages have a signature?
+    pub fn handle_message_id_fetch<R: RngCore + CryptoRng>(
+        &self,
+        _request: MessageChallengeFetchRequest,
+        rng: &mut R,
+    ) -> Result<MessageChallengeFetchResponse, Error> {
+        let messages = self.storage.get_messages();
+        let message_count = messages.len();
+
+        // Fixed response size to prevent traffic analysis
+
+        let mut q_entries = Vec::new();
+        let mut cid_entries = Vec::new();
+
+        // Process real messages
+        for (message_id, message) in messages.iter() {
+            let y = generate_random_scalar(rng).expect("Failed to generate random scalar");
+
+            // k_i = DH(Z_i, y)
+            let z_public_key = dh_public_key_from_scalar(
+                message.dh_share_z.clone().try_into().unwrap_or([0u8; 32]),
+            );
+            let k_i = dh_shared_secret(&z_public_key, y)?.into_bytes();
+
+            // Q_i = DH(X_i, y)
+            let x_public_key = dh_public_key_from_scalar(
+                message.dh_share_x.clone().try_into().unwrap_or([0u8; 32]),
+            );
+            let q_i = dh_shared_secret(&x_public_key, y)?.into_bytes();
+
+            // ID: cid_i = Enc(k_i, id_i)
+            let message_id_bytes = message_id.as_bytes().to_vec();
+            let cid_i =
+                encrypt_message_id(&k_i, &message_id_bytes).expect("Failed to encrypt message ID");
+
+            q_entries.push(q_i.to_vec());
+            cid_entries.push(cid_i);
+        }
+
+        // Fill remaining slots with random data
+        while q_entries.len() < MESSAGE_ID_FETCH_SIZE {
+            // Generate random Q_i that matches the structure of real Q_i
+            // Real Q_i = DH(X_i, y), so random Q_i should also be a DH shared secret
+            let random_y = generate_random_scalar(rng).expect("Failed to generate random scalar");
+            let random_x = generate_random_scalar(rng).expect("Failed to generate random scalar");
+            let random_x_pub = dh_public_key_from_scalar(random_x);
+            let random_q = dh_shared_secret(&random_x_pub, random_y)
+                .map_err(|_| anyhow!("failed to construct shared secret"))?
+                .into_bytes();
+
+            // Generate random cid by encrypting a random UUID
+            // This ensures indistinguishability from real cid_i
+            let random_uuid = Uuid::new_v4();
+            let random_key = generate_random_scalar(rng).expect("Failed to generate random key");
+            let random_cid =
+                crate::primitives::encrypt_message_id(&random_key, random_uuid.as_bytes())
+                    .expect("Failed to encrypt random UUID");
+
+            q_entries.push(random_q.to_vec());
+            cid_entries.push(random_cid);
+        }
+
+        // Shuffle the entries to hide which are real vs random
+        // Zip the arrays together, shuffle, then unzip
+        let mut pairs: Vec<_> = q_entries.into_iter().zip(cid_entries).collect();
+        pairs.shuffle(rng);
+
+        // Unzip back into separate arrays
+        let (q_entries, cid_entries): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
+
+        Ok(MessageChallengeFetchResponse {
+            count: MESSAGE_ID_FETCH_SIZE,
+            messages: q_entries.into_iter().zip(cid_entries).collect(),
+        })
+    }
+
+    /// Handle message fetch request (step 8/10)
+    pub fn handle_message_fetch(
+        &self,
+        _request: MessageFetchRequest,
+    ) -> Option<MessageFetchResponse> {
+        unimplemented!()
+    }
+
+    /// Process a new refresh request from the journalist.
+    ///
+    /// TODO: The caller should persist the keys for J.
+    ///
+    /// Step 3.2 in the 0.2 spec.
+    ///
+    /// TODO(later): How to handle signing when offline? (Not relevant for benchmarking)
+    pub fn handle_journalist_refresh(
+        &mut self,
+        _request: JournalistRefreshRequest,
+    ) -> Result<(), Error> {
+        // TODO: Check signature and store ephemeral keys
+        unimplemented!()
+    }
+}

--- a/securedrop-protocol/src/setup.rs
+++ b/securedrop-protocol/src/setup.rs
@@ -1,0 +1,28 @@
+//! Setup module for FPF hardware operations
+//!
+//! This module contains implementations that run on FPF hardware.
+
+use crate::keys::FPFKeyPair;
+use crate::messages::setup::{NewsroomSetupRequest, NewsroomSetupResponse};
+use anyhow::Error;
+
+impl NewsroomSetupRequest {
+    /// Setup a newsroom. This corresponds to step 2 in the spec.
+    ///
+    /// This runs on FPF hardware.
+    ///
+    /// The generated newsroom verifying key is sent to FPF,
+    /// which produces a signature over the newsroom verifying key using the
+    /// FPF signing key.
+    ///
+    /// TODO: There is a manual verification step here, so the caller should
+    /// instruct the user to stop, verify the fingerprint out of band, and
+    /// then proceed. The caller should also persist the fingerprint and signature
+    /// in its local data store.
+    ///
+    pub fn sign(self, fpf_keys: &FPFKeyPair) -> Result<NewsroomSetupResponse, Error> {
+        let newsroom_pk_bytes = self.newsroom_verifying_key.into_bytes();
+        let sig = fpf_keys.sk.sign(&newsroom_pk_bytes);
+        Ok(NewsroomSetupResponse { sig })
+    }
+}

--- a/securedrop-protocol/src/sign.rs
+++ b/securedrop-protocol/src/sign.rs
@@ -1,0 +1,98 @@
+use anyhow::Error;
+use libcrux_ed25519::{SigningKey as LibCruxSigningKey, VerificationKey as LibCruxVerifyingKey};
+use rand_core::CryptoRng;
+
+/// An Ed25519 signing key.
+pub struct SigningKey {
+    pub vk: VerifyingKey,
+    sk: LibCruxSigningKey,
+}
+
+/// An Ed25519 verification key.
+#[derive(Copy, Clone)]
+pub struct VerifyingKey(LibCruxVerifyingKey);
+
+/// An Ed25519 signature.
+#[derive(Debug, Clone)]
+pub struct Signature(pub [u8; 64]);
+
+impl SigningKey {
+    /// Generate a signing key from the supplied `rng`.
+    pub fn new(mut rng: &mut impl CryptoRng) -> Result<SigningKey, Error> {
+        let (sk, vk) = libcrux_ed25519::generate_key_pair(&mut rng)
+            .map_err(|_| anyhow::anyhow!("Key generation failed"))?;
+
+        Ok(SigningKey {
+            vk: VerifyingKey(vk),
+            sk,
+        })
+    }
+
+    /// Create a signature on `msg` using this `SigningKey`.
+    pub fn sign(&self, msg: &[u8]) -> Signature {
+        let signature_bytes = libcrux_ed25519::sign(msg, self.sk.as_ref())
+            .expect("Signing should not fail with valid key");
+        Signature(signature_bytes)
+    }
+}
+
+impl VerifyingKey {
+    /// Get the raw bytes of this verification key
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0.into_bytes()
+    }
+
+    /// Verify a signature on `msg` using this `VerifyingKey`
+    pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+        libcrux_ed25519::verify(msg, self.0.as_ref(), &signature.0)
+            .map_err(|_| anyhow::anyhow!("Signature verification failed"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rand::rng;
+
+    proptest! {
+        #[test]
+        fn test_sign_verify_roundtrip(msg in proptest::collection::vec(any::<u8>(), 0..100)) {
+            let mut rng = rng();
+            let signing_key = SigningKey::new(&mut rng).unwrap();
+            let signature = signing_key.sign(&msg);
+
+            assert!(signing_key.vk.verify(&msg, &signature).is_ok());
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_verify_fails_with_wrong_message(
+            msg1 in proptest::collection::vec(any::<u8>(), 0..100),
+            msg2 in proptest::collection::vec(any::<u8>(), 0..100)
+        ) {
+            if msg1 == msg2 {
+                return Ok(());
+            }
+
+            let mut rng = rng();
+            let signing_key = SigningKey::new(&mut rng).unwrap();
+            let signature = signing_key.sign(&msg1);
+
+            assert!(signing_key.vk.verify(&msg2, &signature).is_err());
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_verify_fails_with_wrong_key(msg in proptest::collection::vec(any::<u8>(), 0..100)) {
+            let mut rng = rng();
+            let key1 = SigningKey::new(&mut rng).unwrap();
+            let key2 = SigningKey::new(&mut rng).unwrap();
+            let signature = key1.sign(&msg);
+
+            assert!(key2.vk.verify(&msg, &signature).is_err());
+        }
+    }
+}

--- a/securedrop-protocol/src/source.rs
+++ b/securedrop-protocol/src/source.rs
@@ -1,0 +1,214 @@
+//! Source-side protocol implementation
+//!
+//! This module implements the source-side handling of SecureDrop protocol steps 5-10.
+use alloc::vec::Vec;
+use anyhow::Error;
+use rand_core::{CryptoRng, RngCore};
+
+use crate::keys::{
+    JournalistEnrollmentKeyBundle, JournalistOneTimePublicKeys, SourceKeyBundle, SourcePassphrase,
+};
+use crate::messages::core::{
+    Message, MessageChallengeFetchRequest, SourceJournalistKeyRequest, SourceJournalistKeyResponse,
+    SourceMessage, SourceNewsroomKeyRequest, SourceNewsroomKeyResponse,
+};
+use crate::{Client, client::ClientPrivate};
+
+use crate::sign::VerifyingKey;
+
+/// Source session for interacting with the server
+///
+/// TODO: Load from storage
+#[derive(Clone)]
+pub struct SourceClient {
+    /// Source's key bundle derived from passphrase
+    key_bundle: Option<SourceKeyBundle>,
+    /// Newsroom's verifying key (stored after verification)
+    newsroom_verifying_key: Option<VerifyingKey>,
+}
+
+impl SourceClient {
+    /// Initialize source session with keys derived from passphrase (Protocol Step 4)
+    pub fn initialize_with_passphrase<R: RngCore + CryptoRng>(
+        mut rng: R,
+    ) -> (SourcePassphrase, Self) {
+        // Generate a new source key bundle with random passphrase
+        let (passphrase, key_bundle) = SourceKeyBundle::new(&mut rng);
+
+        let session = Self {
+            key_bundle: Some(key_bundle),
+            newsroom_verifying_key: None,
+        };
+
+        (passphrase, session)
+    }
+
+    /// Initialize source session from existing passphrase (Protocol Step 4)
+    pub fn from_passphrase(passphrase: &[u8]) -> Self {
+        let key_bundle = SourceKeyBundle::from_passphrase(passphrase);
+
+        Self {
+            key_bundle: Some(key_bundle),
+            newsroom_verifying_key: None,
+        }
+    }
+
+    /// Get the source's key bundle
+    pub fn key_bundle(&self) -> Option<&SourceKeyBundle> {
+        self.key_bundle.as_ref()
+    }
+}
+
+impl Client for SourceClient {
+    type NewsroomKey = VerifyingKey;
+
+    fn newsroom_verifying_key(&self) -> Option<&Self::NewsroomKey> {
+        self.newsroom_verifying_key.as_ref()
+    }
+
+    fn set_newsroom_verifying_key(&mut self, key: Self::NewsroomKey) {
+        self.newsroom_verifying_key = Some(key);
+    }
+
+    fn fetch_message_ids<R: RngCore + CryptoRng>(
+        &self,
+        _rng: &mut R,
+    ) -> MessageChallengeFetchRequest {
+        MessageChallengeFetchRequest {}
+    }
+}
+
+impl ClientPrivate for SourceClient {
+    fn fetching_private_key(&self) -> Result<[u8; 32], Error> {
+        Ok(self
+            .key_bundle
+            .as_ref()
+            .unwrap()
+            .fetch
+            .private_key
+            .clone()
+            .into_bytes())
+    }
+}
+
+impl SourceClient {
+    /// Fetch newsroom keys (step 5)
+    pub fn fetch_newsroom_keys(&self) -> SourceNewsroomKeyRequest {
+        SourceNewsroomKeyRequest {}
+    }
+
+    /// Handle and verify newsroom key response (step 5)
+    ///
+    /// This verifies the FPF signature on the newsroom's verifying key
+    /// and stores the verified key in the session.
+    pub fn handle_newsroom_key_response(
+        &mut self,
+        response: &SourceNewsroomKeyResponse,
+        fpf_verifying_key: &VerifyingKey,
+    ) -> Result<(), Error> {
+        // Verify the FPF signature on the newsroom's verifying key
+        let newsroom_vk_bytes = response.newsroom_verifying_key.into_bytes();
+        fpf_verifying_key
+            .verify(&newsroom_vk_bytes, &response.fpf_sig)
+            .map_err(|_| anyhow::anyhow!("Invalid FPF signature on newsroom verifying key"))?;
+
+        // Store the verified newsroom verifying key
+        self.newsroom_verifying_key = Some(response.newsroom_verifying_key);
+
+        Ok(())
+    }
+
+    /// Fetch journalist keys (step 5)
+    pub fn fetch_journalist_keys(&self) -> SourceJournalistKeyRequest {
+        SourceJournalistKeyRequest {}
+    }
+
+    /// Handle and verify journalist key response (step 5)
+    ///
+    /// This verifies the newsroom signature on the journalist's keys
+    /// and the journalist signature on the ephemeral keys.
+    pub fn handle_journalist_key_response(
+        &self,
+        response: &SourceJournalistKeyResponse,
+        newsroom_verifying_key: &VerifyingKey,
+    ) -> Result<(), Error> {
+        // Create the enrollment bundle that was signed by the newsroom
+        let enrollment_bundle = JournalistEnrollmentKeyBundle {
+            signing_key: response.journalist_sig_pk,
+            fetching_key: response.journalist_fetch_pk.clone(),
+        };
+
+        // Verify the newsroom signature on the journalist's enrollment bundle
+        newsroom_verifying_key
+            .verify(&enrollment_bundle.into_bytes(), &response.newsroom_sig)
+            .map_err(|_| anyhow::anyhow!("Invalid newsroom signature on journalist keys"))?;
+
+        // Create the one-time keys that were signed by the journalist
+        let one_time_keys = JournalistOneTimePublicKeys {
+            one_time_message_pq_pk: response.one_time_message_pq_pk.clone(),
+            one_time_message_pk: response.one_time_message_pk.clone(),
+            one_time_metadata_pk: response.one_time_metadata_pk.clone(),
+        };
+
+        // Verify the journalist signature on the one-time keys
+        response
+            .journalist_sig_pk
+            .verify(
+                &one_time_keys.into_bytes(),
+                &response.journalist_ephemeral_sig,
+            )
+            .map_err(|_| anyhow::anyhow!("Invalid journalist signature on one-time keys"))?;
+
+        Ok(())
+    }
+
+    /// Submit a message (step 6)
+    pub fn submit_message<R: RngCore + CryptoRng>(
+        &self,
+        message: Vec<u8>,
+        journalist_responses: &[SourceJournalistKeyResponse],
+        rng: &mut R,
+    ) -> Result<Vec<Message>, Error> {
+        let key_bundle = self
+            .key_bundle
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Source key bundle not initialized"))?;
+
+        let mut requests = Vec::new();
+
+        // Submit a distinct copy of the message to each journalist
+        for journalist_response in journalist_responses {
+            // TODO: update for 0.3
+
+            // // 1. Create the structured message according to Step 6 format:
+            // // msg || S_dh,pk || S_pke,pk || S_kem,pk || S_fetch,pk || J^i_sig,pk || NR
+            // let source_message = SourceMessage {
+            //     message: message.clone(),
+            //     source_message_pq_pk: key_bundle.long_term_dh.public_key.clone(),
+            //     source_message_pk: key_bundle.pke.public_key.clone(),
+            //     source_metadata_pk: key_bundle.kem.public_key.clone(),
+            //     source_fetch_pk: key_bundle.fetch.public_key.clone(),
+            //     journalist_sig_pk: journalist_response.journalist_sig_pk,
+            //     newsroom_sig_pk: self.get_newsroom_verifying_key()?.clone(),
+            // };
+
+            // // 2. Use the shared method for encryption and message creation
+            // let request = self.submit_structured_message(
+            //     source_message,
+            //     (
+            //         &journalist_response.one_time_message_pq_pk,
+            //         &journalist_response.one_time_message_pk,
+            //     ),
+            //     &journalist_response.one_time_metadata_pk,
+            //     &journalist_response.journalist_fetch_pk,
+            //     &key_bundle.long_term_dh.private_key,
+            //     &key_bundle.long_term_dh.public_key,
+            //     rng,
+            // )?;
+
+            //requests.push(request);
+        }
+
+        Ok(requests)
+    }
+}

--- a/securedrop-protocol/src/storage.rs
+++ b/securedrop-protocol/src/storage.rs
@@ -1,0 +1,145 @@
+use alloc::vec::Vec;
+use hashbrown::HashMap;
+use rand::Rng;
+use rand_core::CryptoRng;
+use uuid::Uuid;
+
+use crate::keys::{JournalistEnrollmentKeyBundle, JournalistOneTimeKeyBundle};
+use crate::messages::core::Message;
+use crate::primitives::x25519::DHPublicKey;
+use crate::sign::{Signature, VerifyingKey};
+
+#[derive(Default)]
+pub struct ServerStorage {
+    /// Journalists with their long/medium term keys
+    journalists: HashMap<Uuid, (VerifyingKey, DHPublicKey, Signature)>,
+    /// Journalists ephemeral keystore
+    /// Maps journalist ID to a vector of ephemeral key sets
+    /// Each journalist maintains a pool of ephemeral keys that are randomly selected and removed when fetched
+    ephemeral_keys: HashMap<Uuid, Vec<JournalistOneTimeKeyBundle>>,
+    /// Store of messages
+    messages: HashMap<Uuid, Message>,
+}
+
+impl ServerStorage {
+    /// Create a new ServerStorage instance
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add ephemeral keys for a journalist
+    pub fn add_ephemeral_keys(
+        &mut self,
+        journalist_id: Uuid,
+        keys: Vec<JournalistOneTimeKeyBundle>,
+    ) {
+        let journalist_keys = self
+            .ephemeral_keys
+            .entry(journalist_id)
+            .or_insert_with(Vec::new);
+        journalist_keys.extend(keys);
+    }
+
+    /// Get a random ephemeral key set for a journalist and remove it from the pool
+    /// Returns None if no keys are available for this journalist
+    ///
+    /// Note: This method deletes the ephemeral key from storage.
+    /// The returned key is permanently removed from the journalist's ephemeral key pool.
+    pub fn pop_random_ephemeral_keys<R: rand::RngCore + CryptoRng>(
+        &mut self,
+        journalist_id: Uuid,
+        rng: &mut R,
+    ) -> Option<JournalistOneTimeKeyBundle> {
+        if let Some(keys) = self.ephemeral_keys.get_mut(&journalist_id) {
+            if keys.is_empty() {
+                return None;
+            }
+
+            // Select a random index
+            let index = rng.random_range(0..keys.len());
+
+            // Remove and return the selected key set
+            Some(keys.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// Get random ephemeral keys for all journalists
+    /// Returns a vector of (journalist_id, ephemeral_keys) pairs
+    /// Only includes journalists that have available keys
+    ///
+    /// Note: This method deletes the ephemeral keys from storage.
+    /// Each call removes the returned keys from the journalist's ephemeral key pool.
+    pub fn get_all_ephemeral_keys<R: rand::RngCore + CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> Vec<(Uuid, JournalistOneTimeKeyBundle)> {
+        let mut result = Vec::new();
+        let journalist_ids: Vec<Uuid> = self.ephemeral_keys.keys().copied().collect();
+
+        for journalist_id in journalist_ids {
+            if let Some(keys) = self.pop_random_ephemeral_keys(journalist_id, rng) {
+                result.push((journalist_id, keys));
+            }
+        }
+
+        result
+    }
+
+    /// Check how many ephemeral keys are available for a journalist
+    pub fn ephemeral_keys_count(&self, journalist_id: Uuid) -> usize {
+        self.ephemeral_keys
+            .get(&journalist_id)
+            .map_or(0, |keys| keys.len())
+    }
+
+    /// Check if a journalist has any ephemeral keys available
+    pub fn has_ephemeral_keys(&self, journalist_id: Uuid) -> bool {
+        self.ephemeral_keys_count(journalist_id) > 0
+    }
+
+    /// Get all journalists
+    pub fn get_journalists(&self) -> &HashMap<Uuid, (VerifyingKey, DHPublicKey, Signature)> {
+        &self.journalists
+    }
+
+    /// Add a journalist to storage and return the generated UUID
+    pub fn add_journalist(
+        &mut self,
+        enrollment_bundle: JournalistEnrollmentKeyBundle,
+        signature: Signature,
+    ) -> Uuid {
+        let journalist_id = Uuid::new_v4();
+        let keys = (
+            enrollment_bundle.signing_key,
+            enrollment_bundle.fetching_key,
+            signature,
+        );
+        self.journalists.insert(journalist_id, keys);
+        journalist_id
+    }
+
+    /// Find a journalist by their verifying key
+    /// Returns the journalist ID if found
+    ///
+    /// TODO: Remove?
+    pub fn find_journalist_by_verifying_key(&self, verifying_key: &VerifyingKey) -> Option<Uuid> {
+        for (journalist_id, (stored_vk, _, _)) in &self.journalists {
+            if stored_vk.into_bytes() == verifying_key.into_bytes() {
+                return Some(*journalist_id);
+            }
+        }
+        None
+    }
+
+    /// Get all messages
+    pub fn get_messages(&self) -> &HashMap<Uuid, Message> {
+        &self.messages
+    }
+
+    /// Add a message to storage
+    pub fn add_message(&mut self, message_id: Uuid, message: Message) {
+        self.messages.insert(message_id, message);
+    }
+}

--- a/securedrop-protocol/tests/bench_loops.rs
+++ b/securedrop-protocol/tests/bench_loops.rs
@@ -1,0 +1,11 @@
+use securedrop_protocol::bench::{encrypt_decrypt_bench, submit_bench};
+
+#[test]
+fn run_encrypt_decrypt_bench_loop() {
+    encrypt_decrypt_bench(1);
+}
+
+#[test]
+fn run_submit_bench_loop() {
+    submit_bench(1);
+}

--- a/securedrop-protocol/tests/core.rs
+++ b/securedrop-protocol/tests/core.rs
@@ -1,0 +1,353 @@
+//! Tests for the core steps of the protocol.
+//! These correspond to steps 5-10 of the spec.
+
+use rand::rng;
+
+use securedrop_protocol::Client;
+use securedrop_protocol::journalist::JournalistClient;
+use securedrop_protocol::keys::{
+    FPFKeyPair, JournalistOneTimePublicKeys, JournalistSigningKeyPair, NewsroomKeyPair,
+    SourceKeyBundle,
+};
+use securedrop_protocol::messages::setup::{
+    JournalistRefreshRequest, JournalistSetupRequest, NewsroomSetupRequest, NewsroomSetupResponse,
+};
+use securedrop_protocol::primitives::MESSAGE_ID_FETCH_SIZE;
+use securedrop_protocol::server::Server;
+use securedrop_protocol::source::SourceClient;
+use securedrop_protocol::storage::ServerStorage;
+
+/// Step 5: Source fetches keys and verifies their authenticity
+#[test]
+#[ignore]
+fn protocol_step_5_source_fetch_keys() {
+    let mut rng = rng();
+
+    // Setup: Create server with newsroom and journalist
+    let mut server_session = Server::new();
+
+    // Setup newsroom
+    let newsroom_setup_request = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    // Store the newsroom verifying key for verification
+    let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
+
+    // Simulate FPF signing (in real implementation, this would be done by FPF)
+    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let newsroom_setup_response = newsroom_setup_request
+        .sign(&fpf_keypair)
+        .expect("Can sign newsroom setup request");
+
+    // Store the FPF signature in the server session for later use
+    server_session.set_fpf_signature(newsroom_setup_response.sig);
+
+    // Setup journalist
+    let mut journalist_session = JournalistClient::new();
+    let journalist_setup_request = journalist_session
+        .create_setup_request(&mut rng)
+        .expect("Can create journalist setup request");
+
+    server_session
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // Journalist provides ephemeral keys
+    let ephemeral_key_request = journalist_session
+        .create_ephemeral_key_request(&mut rng)
+        .expect("Can create ephemeral key request");
+
+    server_session
+        .handle_ephemeral_key_request(ephemeral_key_request)
+        .expect("Can handle ephemeral key request");
+
+    // Step 4: Generate source session from passphrase
+    let mut source_session = SourceClient::from_passphrase(&[1u8; 32]);
+
+    // Step 5: Source fetches newsroom keys
+    let newsroom_key_request = source_session.fetch_newsroom_keys();
+    let newsroom_key_response =
+        server_session.handle_source_newsroom_key_request(newsroom_key_request);
+
+    // Source handles and verifies the newsroom key response
+    source_session
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .expect("Newsroom key response should be valid");
+
+    // Source fetches journalist keys
+    let journalist_key_request = source_session.fetch_journalist_keys();
+    let journalist_key_responses =
+        server_session.handle_source_journalist_key_request(journalist_key_request, &mut rng);
+
+    // We only have one journalist rn
+    let journalist_response = &journalist_key_responses[0];
+
+    // Source handles and verifies the journalist key response
+    source_session
+        .handle_journalist_key_response(journalist_response, &newsroom_verifying_key)
+        .expect("Journalist key response should be valid");
+
+    // Verify the journalist's signing key matches our expectation
+    let journalist_verifying_key = journalist_session
+        .verifying_key()
+        .expect("Journalist should have verifying key");
+    assert_eq!(
+        journalist_response.journalist_sig_pk.into_bytes(),
+        journalist_verifying_key.into_bytes()
+    );
+
+    // Verify the journalist's fetch key matches our expectation
+    let journalist_fetch_key = journalist_session
+        .fetching_key()
+        .expect("Journalist should have fetching key");
+    assert_eq!(
+        journalist_response.journalist_fetch_pk.clone().into_bytes(),
+        journalist_fetch_key.clone().into_bytes()
+    );
+
+    // Verify the journalist's DH key matches our expectation
+    let journalist_dh_key = journalist_session
+        .dh_key()
+        .expect("Journalist should have DH key");
+    assert_eq!(
+        journalist_response.journalist_dh_pk.clone().into_bytes(),
+        journalist_dh_key.clone().into_bytes()
+    );
+
+    // Verify that ephemeral keys were consumed (deleted from server storage)
+    // After fetching, the journalist should have no ephemeral keys left
+    let journalist_id = server_session
+        .find_journalist_id(journalist_verifying_key)
+        .expect("Journalist should be found");
+    assert_eq!(server_session.ephemeral_keys_count(journalist_id), 0);
+    assert!(!server_session.has_ephemeral_keys(journalist_id));
+
+    // Test that subsequent requests return no keys (since they were consumed)
+    let empty_journalist_key_request = source_session.fetch_journalist_keys();
+    let empty_responses =
+        server_session.handle_source_journalist_key_request(empty_journalist_key_request, &mut rng);
+    assert_eq!(empty_responses.len(), 0);
+
+    // Test that invalid FPF signatures are rejected
+    let wrong_fpf_keypair = FPFKeyPair::new(&mut rng);
+    assert!(
+        source_session
+            .handle_newsroom_key_response(&newsroom_key_response, &wrong_fpf_keypair.vk)
+            .is_err()
+    );
+
+    // Test that invalid newsroom signatures on journalist keys are rejected
+    let wrong_newsroom_keypair = NewsroomKeyPair::new(&mut rng);
+    assert!(
+        source_session
+            .handle_journalist_key_response(journalist_response, &wrong_newsroom_keypair.vk)
+            .is_err()
+    );
+}
+
+/// Step 6: Source submits a message
+#[test]
+#[ignore]
+fn protocol_step_6_source_submits_message() {
+    let mut rng = rng();
+
+    // Setup: Complete steps 1-5 (reuse from previous test)
+    let mut server_session = Server::new();
+
+    // Setup newsroom
+    let newsroom_setup_request = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
+
+    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let newsroom_setup_response = newsroom_setup_request
+        .sign(&fpf_keypair)
+        .expect("Can sign newsroom setup request");
+
+    server_session.set_fpf_signature(newsroom_setup_response.sig);
+
+    // Setup journalist
+    let mut journalist_session = JournalistClient::new();
+    let journalist_setup_request = journalist_session
+        .create_setup_request(&mut rng)
+        .expect("Can create journalist setup request");
+
+    server_session
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // Store the newsroom verifying key in the journalist session
+    journalist_session.set_newsroom_verifying_key(newsroom_verifying_key);
+
+    // Journalist provides ephemeral keys
+    let ephemeral_key_request = journalist_session
+        .create_ephemeral_key_request(&mut rng)
+        .expect("Can create ephemeral key request");
+
+    server_session
+        .handle_ephemeral_key_request(ephemeral_key_request)
+        .expect("Can handle ephemeral key request");
+
+    // Source setup
+    let mut source_session = SourceClient::from_passphrase(&[1u8; 32]);
+
+    // Source fetches keys (Step 5)
+    let newsroom_key_request = source_session.fetch_newsroom_keys();
+    let newsroom_key_response =
+        server_session.handle_source_newsroom_key_request(newsroom_key_request);
+
+    source_session
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .expect("Newsroom key response should be valid");
+
+    let journalist_key_request = source_session.fetch_journalist_keys();
+    let journalist_key_responses =
+        server_session.handle_source_journalist_key_request(journalist_key_request, &mut rng);
+
+    let journalist_response = &journalist_key_responses[0];
+
+    source_session
+        .handle_journalist_key_response(journalist_response, &newsroom_verifying_key)
+        .expect("Journalist key response should be valid");
+
+    // Step 6: Source submits a message
+    let message_content = b"Hello, this is a test message!";
+    let messages = source_session
+        .submit_message(
+            message_content.to_vec(),
+            &journalist_key_responses,
+            &mut rng,
+        )
+        .expect("Can submit message");
+
+    // Verify that we got one message per journalist
+    assert_eq!(messages.len(), 1);
+
+    let message = &messages[0];
+
+    // Submit the message to the server
+    let message_id = server_session
+        .handle_message_submit(message.clone())
+        .expect("Can handle message submission");
+
+    // Verify that the message was stored
+    assert!(server_session.has_message(&message_id));
+}
+
+#[ignore]
+/// Step 7: Privacy-preserving message ID fetch
+#[test]
+fn protocol_step_7_message_id_fetch() {
+    let mut rng = rng();
+
+    // Setup: Complete steps 1-6 (reuse from previous test)
+    let mut server_session = Server::new();
+
+    // Setup newsroom
+    let newsroom_setup_request = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    let newsroom_verifying_key = newsroom_setup_request.newsroom_verifying_key;
+
+    let fpf_keypair = FPFKeyPair::new(&mut rng);
+    let newsroom_setup_response = newsroom_setup_request
+        .sign(&fpf_keypair)
+        .expect("Can sign newsroom setup request");
+
+    server_session.set_fpf_signature(newsroom_setup_response.sig);
+
+    // Setup journalist
+    let mut journalist_session = JournalistClient::new();
+    let journalist_setup_request = journalist_session
+        .create_setup_request(&mut rng)
+        .expect("Can create journalist setup request");
+
+    server_session
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // Store the newsroom verifying key in the journalist session
+    journalist_session.set_newsroom_verifying_key(newsroom_verifying_key);
+
+    // Journalist provides ephemeral keys
+    let ephemeral_key_request = journalist_session
+        .create_ephemeral_key_request(&mut rng)
+        .expect("Can create ephemeral key request");
+
+    server_session
+        .handle_ephemeral_key_request(ephemeral_key_request)
+        .expect("Can handle ephemeral key request");
+
+    // Source setup
+    let mut source_session = SourceClient::from_passphrase(&[1u8; 32]);
+
+    // Source fetches keys (Step 5)
+    let newsroom_key_request = source_session.fetch_newsroom_keys();
+    let newsroom_key_response =
+        server_session.handle_source_newsroom_key_request(newsroom_key_request);
+
+    source_session
+        .handle_newsroom_key_response(&newsroom_key_response, &fpf_keypair.vk)
+        .expect("Newsroom key response should be valid");
+
+    let journalist_key_request = source_session.fetch_journalist_keys();
+    let journalist_key_responses =
+        server_session.handle_source_journalist_key_request(journalist_key_request, &mut rng);
+
+    let journalist_response = &journalist_key_responses[0];
+
+    source_session
+        .handle_journalist_key_response(journalist_response, &newsroom_verifying_key)
+        .expect("Journalist key response should be valid");
+
+    // Submit a message (Step 6)
+    let message_content = b"Hello, this is a test message!";
+    let messages = source_session
+        .submit_message(
+            message_content.to_vec(),
+            &journalist_key_responses,
+            &mut rng,
+        )
+        .expect("Can submit message");
+
+    let message = &messages[0];
+    let message_id = server_session
+        .handle_message_submit(message.clone())
+        .expect("Can handle message submission");
+
+    // Step 7: Test message ID fetch from journalist perspective
+    let journalist_fetch_request = journalist_session.fetch_message_ids(&mut rng);
+    let journalist_fetch_response = server_session
+        .handle_message_id_fetch(journalist_fetch_request, &mut rng)
+        .expect("should be able to fetch message IDs");
+
+    // Verify response structure
+    assert_eq!(journalist_fetch_response.count, MESSAGE_ID_FETCH_SIZE);
+    assert_eq!(
+        journalist_fetch_response.messages.len(),
+        MESSAGE_ID_FETCH_SIZE
+    );
+
+    // Process the response to extract message IDs
+    let journalist_message_ids = journalist_session
+        .process_message_id_response(&journalist_fetch_response)
+        .expect("Can process message ID response");
+
+    // Verify that the journalist can also find the message ID
+    assert!(
+        journalist_message_ids.contains(&message_id),
+        "Journalist should find the message ID"
+    );
+
+    // Verify privacy properties: response size is always the same
+    let empty_fetch_request = source_session.fetch_message_ids(&mut rng);
+    let empty_fetch_response = server_session
+        .handle_message_id_fetch(empty_fetch_request, &mut rng)
+        .expect("we should be able to handle message ID fetch");
+    assert_eq!(empty_fetch_response.count, MESSAGE_ID_FETCH_SIZE);
+    assert_eq!(empty_fetch_response.messages.len(), MESSAGE_ID_FETCH_SIZE);
+}

--- a/securedrop-protocol/tests/setup.rs
+++ b/securedrop-protocol/tests/setup.rs
@@ -1,0 +1,223 @@
+//! Tests for the setup steps of the protocol.
+//! These correspond to steps 1-4 of the spec.
+
+use rand::rng;
+
+use securedrop_protocol::journalist::JournalistClient;
+use securedrop_protocol::keys::{
+    FPFKeyPair, JournalistOneTimePublicKeys, JournalistSigningKeyPair, NewsroomKeyPair,
+    SourceKeyBundle,
+};
+use securedrop_protocol::messages::setup::{
+    JournalistRefreshRequest, JournalistSetupRequest, NewsroomSetupRequest, NewsroomSetupResponse,
+};
+use securedrop_protocol::server::Server;
+use securedrop_protocol::source::SourceClient;
+use securedrop_protocol::storage::ServerStorage;
+
+/// Step 1: Generate FPF keys
+#[test]
+fn protocol_step_1_generate_fpf_keys() {
+    let mut rng = rng();
+    let fpf_keys = FPFKeyPair::new(&mut rng);
+
+    // Test signing/verification roundtrip
+    let message = b"test message";
+    let signature = fpf_keys.sk.sign(message);
+    assert!(fpf_keys.vk.verify(message, &signature).is_ok());
+}
+
+/// Step 2: Newsroom setup
+#[test]
+fn protocol_step_2_generate_newsroom_keys() {
+    let mut rng = rng();
+
+    // Setup: FPF generates their keys (from previous step)
+    let fpf_keys = FPFKeyPair::new(&mut rng);
+
+    // Newsroom: Create server session and generate setup request
+    let mut server_session = Server::new();
+    let newsroom_setup = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    // Store the newsroom verifying key for verification
+    let newsroom_vk = newsroom_setup.newsroom_verifying_key;
+
+    // Sign the newsroom's public key
+    let setup_response = newsroom_setup
+        .sign(&fpf_keys)
+        .expect("Signing should not fail");
+
+    // Newsroom: Verify the FPF signature on the newsroom's public key
+    let newsroom_pk_bytes = newsroom_vk.into_bytes();
+    assert!(
+        fpf_keys
+            .vk
+            .verify(&newsroom_pk_bytes, &setup_response.sig)
+            .is_ok()
+    );
+}
+
+/// Step 3.1: Journalist enrollment
+#[test]
+fn protocol_step_3_1_journalist_enrollment() {
+    let mut rng = rng();
+
+    // Setup: FPF generates their keys (from step 1)
+    let fpf_keys = FPFKeyPair::new(&mut rng);
+
+    // Setup: Newsroom creates server session and generates setup request (from step 2)
+    let mut server_session = Server::new();
+    let newsroom_setup = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    // FPF signs the newsroom's public key (from step 2)
+    let _setup_response = newsroom_setup
+        .sign(&fpf_keys)
+        .expect("Signing should not fail");
+
+    // Journalist: Create journalist session and generate setup request
+    let mut journalist_session = JournalistClient::new();
+    let journalist_setup_request = journalist_session
+        .create_setup_request(&mut rng)
+        .expect("Can create journalist setup request");
+
+    // Extract enrollment bundle for verification before moving the request
+    let enrollment_bundle = journalist_setup_request.enrollment_key_bundle.clone();
+
+    // Newsroom: Process journalist setup request and sign the enrollment bundle
+    let journalist_setup_response = server_session
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // Journalist: Verify the newsroom signature on the enrollment bundle
+    let enrollment_bundle_bytes = enrollment_bundle.into_bytes();
+    let newsroom_vk = server_session
+        .get_newsroom_verifying_key()
+        .expect("Newsroom keys should be available");
+    assert!(
+        newsroom_vk
+            .verify(&enrollment_bundle_bytes, &journalist_setup_response.sig)
+            .is_ok()
+    );
+
+    // Test that wrong bundle bytes fail verification
+    let wrong_bundle_bytes = [0u8; 96];
+    assert!(
+        newsroom_vk
+            .verify(&wrong_bundle_bytes, &journalist_setup_response.sig)
+            .is_err()
+    );
+}
+
+/// Step 3.2: Journalist ephemeral key replenishment
+#[test]
+fn protocol_step_3_2_journalist_ephemeral_keys() {
+    let mut rng = rng();
+
+    // Setup: FPF generates their keys (Step 1)
+    let fpf_keys = FPFKeyPair::new(&mut rng);
+
+    // Setup: Newsroom creates server session and generates setup request (Step 2)
+    let mut server_session = Server::new();
+    let newsroom_setup = server_session
+        .create_newsroom_setup_request(&mut rng)
+        .expect("Can create newsroom setup request");
+
+    // FPF signs the newsroom's public key (Step 2)
+    let _setup_response = newsroom_setup
+        .sign(&fpf_keys)
+        .expect("Signing should not fail");
+
+    // Setup: Journalist enrollment (Step 3.1)
+    let mut journalist_session = JournalistClient::new();
+    let journalist_setup_request = journalist_session
+        .create_setup_request(&mut rng)
+        .expect("Can create journalist setup request");
+
+    // Extract enrollment bundle for verification before moving the request
+    let enrollment_bundle = journalist_setup_request.enrollment_key_bundle.clone();
+
+    // Newsroom: Process journalist setup request and sign the enrollment bundle
+    let journalist_setup_response = server_session
+        .setup_journalist(journalist_setup_request)
+        .expect("Can setup journalist");
+
+    // Journalist: Verify the newsroom signature on the enrollment bundle
+    let enrollment_bundle_bytes = enrollment_bundle.into_bytes();
+    let newsroom_vk = server_session
+        .get_newsroom_verifying_key()
+        .expect("Newsroom keys should be available");
+    assert!(
+        newsroom_vk
+            .verify(&enrollment_bundle_bytes, &journalist_setup_response.sig)
+            .is_ok()
+    );
+
+    // Step 3.2: Journalist generates ephemeral keys and signs them
+    // Journalist creates ephemeral key request
+    let ephemeral_key_request = journalist_session
+        .create_ephemeral_key_request(&mut rng)
+        .expect("Can create ephemeral key request");
+
+    // Get the verifying key for verification
+    let journalist_verifying_key = journalist_session
+        .verifying_key()
+        .expect("Verifying key should be available after setup");
+
+    // Extract bundle for verification before moving the request
+    let ephemeral_bundle = ephemeral_key_request.ephemeral_key_bundle.clone();
+
+    // Server: Process ephemeral key request
+    let ephemeral_key_response = server_session
+        .handle_ephemeral_key_request(ephemeral_key_request)
+        .expect("Can handle ephemeral key request");
+
+    assert!(ephemeral_key_response.success);
+
+    // Get the ephemeral public keys from the bundle
+    let ephemeral_public_keys = &ephemeral_bundle.public_keys;
+
+    // Verify the journalist's signature on the ephemeral keys
+    let ephemeral_keys_bytes = ephemeral_public_keys.clone().into_bytes();
+
+    assert!(
+        journalist_verifying_key
+            .verify(&ephemeral_keys_bytes, &ephemeral_bundle.signature)
+            .is_ok()
+    );
+
+    // Test that wrong ephemeral keys bytes fail verification
+    let wrong_ephemeral_bytes = [0u8; 96];
+    assert!(
+        journalist_verifying_key
+            .verify(&wrong_ephemeral_bytes, &ephemeral_bundle.signature)
+            .is_err()
+    );
+
+    // Test that server rejects ephemeral keys from unknown journalist
+    let unknown_journalist_request = JournalistRefreshRequest {
+        journalist_verifying_key: FPFKeyPair::new(&mut rng).vk, // Use a different key
+        ephemeral_key_bundle: ephemeral_bundle.clone(),
+    };
+    assert!(
+        server_session
+            .handle_ephemeral_key_request(unknown_journalist_request)
+            .is_err()
+    );
+}
+
+/// Step 4: Source setup - derive keys from passphrase
+#[test]
+fn protocol_step_4_source_setup() {
+    let mut rng = rng();
+
+    // Initialize source session with new passphrase (Protocol Step 4)
+    let (passphrase, source_session) = SourceClient::initialize_with_passphrase(&mut rng);
+
+    // Verify that all keys were generated
+    assert_eq!(passphrase.passphrase.len(), 32);
+    assert!(source_session.key_bundle().is_some());
+}

--- a/www/index.html
+++ b/www/index.html
@@ -10,6 +10,9 @@ import init, { generate_x25519_keypair, hpke_encrypt } from '../pkg/sd_wasm.js';
 
 async function run() {
     await init();
+    // Expose wasm functions globally so Playwright can access them
+    window.generate_x25519_keypair = generate_x25519_keypair;
+    window.hpke_encrypt = hpke_encrypt;
     const kp = generate_x25519_keypair();
     console.log('public key', new Uint8Array(kp.public_key));
     const msg = new TextEncoder().encode('hello');


### PR DESCRIPTION
## Summary
- add Makefile target to install Playwright, browsers and run HPKE benchmarks
- expose wasm bindings and add JS harness for running benchmarks in Chromium and Firefox

## Testing
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_689a2bb575588328959ee7448394f855